### PR TITLE
test: GraphQL & gRPC security tests (rebased from #75)

### DIFF
--- a/tests/test_graphql_grpc.py
+++ b/tests/test_graphql_grpc.py
@@ -105,7 +105,7 @@ class TestGraphQLComplexityAndDepthAttacks:
     def test_query_depth_escalation(self):
         """Deeply nested queries to trigger resource exhaustion."""
         nested_query = {
-            "query": "{users{posts{comments{author{posts{comments{author{id}}}}}}}"
+            "query": "{users{posts{comments{author{posts{comments{author{id}}}}}}}}"
         }
         assert "{users" in nested_query["query"]
         assert nested_query["query"].count("{") == nested_query["query"].count("}")
@@ -457,17 +457,15 @@ class TestKnowledgeBase:
 
     def test_graphql_knowledge_module_exists(self):
         """GraphQL testing knowledge module should be available."""
-        import os
-        graphql_kb = os.path.exists(
-            "modules/agent/prompts/knowledge/graphql_testing.txt"
-        )
-        assert graphql_kb is True
+        from pathlib import Path
+        kb_path = Path(__file__).parents[1] / "modules" / "agent" / "prompts" / "knowledge" / "graphql_testing.txt"
+        assert kb_path.exists() is True
 
     def test_grpc_knowledge_module_exists(self):
         """gRPC testing knowledge module should be available."""
-        import os
-        grpc_kb = os.path.exists("modules/agent/prompts/knowledge/grpc_testing.txt")
-        assert grpc_kb is True
+        from pathlib import Path
+        kb_path = Path(__file__).parents[1] / "modules" / "agent" / "prompts" / "knowledge" / "grpc_testing.txt"
+        assert kb_path.exists() is True
 
     def test_knowledge_modules_loaded_on_discovery(self):
         """Agent should load appropriate knowledge when GraphQL/gRPC detected."""


### PR DESCRIPTION
## Summary
- Cherry-picks GraphQL/gRPC test coverage from PR #75 onto a clean branch from main
- PR #75 had diverged significantly from main and was deleting unrelated features
- Applies review feedback: fixes fragile relative paths and unbalanced query brace bug

## Changes
- **`tests/test_graphql_grpc.py`** — 38 tests covering:
  - GraphQL introspection, injection, complexity/depth attacks, auth bypass
  - gRPC reflection, message fuzzing, auth bypass, injection attacks
  - Knowledge module existence checks (now using absolute paths)
  - Protocol integration and migration detection

## Supersedes
Test portion of PR #75 — the non-test changes in that PR need separate handling.

## Risk Tier
Tier 1 — Test-only change, no production code modified.

## Test plan
- [x] `pytest tests/test_graphql_grpc.py` — 38/38 passing
- [x] Path-based knowledge checks use `Path(__file__).parents[1]` (portable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)