### PR TITLE
test: comprehensive triage & scheduling test coverage (#6, #7)

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,0 +1,213 @@
+"""Tests for intelligent scan scheduling — interval recommendation logic."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from modules.agent.scheduling import (
+    _classify_target_criticality,
+    _compute_change_rate,
+    _vulnerability_density,
+    recommend_scan_interval,
+)
+
+
+class TestTargetCriticality(unittest.TestCase):
+
+    def test_payment_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://payment.example.com"), "critical")
+
+    def test_login_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://example.com/login"), "critical")
+
+    def test_auth_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://auth.example.com"), "critical")
+
+    def test_api_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://api.example.com"), "critical")
+
+    def test_graphql_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://example.com/graphql"), "critical")
+
+    def test_admin_is_critical(self):
+        self.assertEqual(_classify_target_criticality("https://admin.example.com"), "critical")
+
+    def test_app_is_medium(self):
+        self.assertEqual(_classify_target_criticality("https://app.example.com"), "medium")
+
+    def test_portal_is_medium(self):
+        self.assertEqual(_classify_target_criticality("https://portal.example.com"), "medium")
+
+    def test_static_site_is_low(self):
+        self.assertEqual(_classify_target_criticality("https://blog.example.com"), "low")
+
+    def test_case_insensitive(self):
+        self.assertEqual(_classify_target_criticality("https://PAYMENT.example.com"), "critical")
+
+
+class TestChangeRate(unittest.TestCase):
+
+    def test_no_history(self):
+        self.assertEqual(_compute_change_rate([]), 0.0)
+
+    def test_single_scan(self):
+        self.assertEqual(_compute_change_rate([{"findings_count": 10}]), 0.0)
+
+    def test_stable_target(self):
+        history = [
+            {"findings_count": 5},
+            {"findings_count": 5},
+            {"findings_count": 5},
+        ]
+        self.assertEqual(_compute_change_rate(history), 0.0)
+
+    def test_volatile_target(self):
+        history = [
+            {"findings_count": 10},
+            {"findings_count": 2},
+            {"findings_count": 8},
+        ]
+        # deltas: |10-2|=8, |2-8|=6, avg=7
+        self.assertEqual(_compute_change_rate(history), 7.0)
+
+    def test_gradually_increasing(self):
+        history = [
+            {"findings_count": 3},
+            {"findings_count": 2},
+            {"findings_count": 1},
+        ]
+        # deltas: 1, 1, avg=1
+        self.assertEqual(_compute_change_rate(history), 1.0)
+
+
+class TestVulnerabilityDensity(unittest.TestCase):
+
+    def test_empty_history(self):
+        self.assertEqual(_vulnerability_density([]), 0.0)
+
+    def test_single_scan(self):
+        self.assertEqual(_vulnerability_density([{"findings_count": 15}]), 15.0)
+
+    def test_average_calculation(self):
+        history = [
+            {"findings_count": 10},
+            {"findings_count": 20},
+        ]
+        self.assertEqual(_vulnerability_density(history), 15.0)
+
+
+class TestRecommendScanInterval(unittest.TestCase):
+
+    def test_clean_static_site_gets_monthly(self):
+        result = recommend_scan_interval(
+            "https://blog.example.com",
+            {"findings": [], "risk_score": 5},
+            scan_history=[],
+        )
+        self.assertEqual(result["recommended_scan_interval"], "monthly")
+        self.assertIn("recommended", result["interval_reasoning"].lower())
+
+    def test_high_risk_auth_target_gets_daily(self):
+        findings = [
+            {"severity": "critical"},
+            {"severity": "critical"},
+            {"severity": "high"},
+            {"severity": "high"},
+        ]
+        history = [
+            {"findings_count": 10},
+            {"findings_count": 3},
+        ]
+        result = recommend_scan_interval(
+            "https://auth.example.com/login",
+            {"findings": findings, "risk_score": 85},
+            scan_history=history,
+        )
+        self.assertEqual(result["recommended_scan_interval"], "daily")
+
+    def test_moderate_risk_gets_weekly_or_biweekly(self):
+        findings = [{"severity": "high"}, {"severity": "medium"}]
+        result = recommend_scan_interval(
+            "https://app.example.com",
+            {"findings": findings, "risk_score": 45},
+            scan_history=[],
+        )
+        self.assertIn(result["recommended_scan_interval"], ["weekly", "biweekly"])
+
+    def test_no_history_note_in_reasoning(self):
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": [], "risk_score": 0},
+            scan_history=[],
+        )
+        self.assertIn("No prior scan history", result["interval_reasoning"])
+
+    def test_stable_target_with_history_mentions_stable(self):
+        history = [
+            {"findings_count": 3},
+            {"findings_count": 3},
+            {"findings_count": 3},
+        ]
+        result = recommend_scan_interval(
+            "https://blog.example.com",
+            {"findings": [], "risk_score": 10},
+            scan_history=history,
+        )
+        self.assertIn("stable", result["interval_reasoning"].lower())
+
+    def test_high_volatility_increases_frequency(self):
+        history = [
+            {"findings_count": 20},
+            {"findings_count": 2},
+            {"findings_count": 18},
+        ]
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": [{"severity": "medium"}], "risk_score": 30},
+            scan_history=history,
+        )
+        # High volatility should push toward more frequent scanning
+        self.assertIn(result["recommended_scan_interval"], ["daily", "weekly", "biweekly"])
+        self.assertIn("volatility", result["interval_reasoning"].lower())
+
+    def test_vulnerability_dense_target(self):
+        history = [{"findings_count": 15}, {"findings_count": 12}]
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": [{"severity": "medium"}], "risk_score": 30},
+            scan_history=history,
+        )
+        self.assertIn("vulnerability-dense", result["interval_reasoning"])
+
+    def test_return_structure(self):
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": []},
+            scan_history=[],
+        )
+        self.assertIn("recommended_scan_interval", result)
+        self.assertIn("interval_reasoning", result)
+        self.assertIn(result["recommended_scan_interval"],
+                       ["daily", "weekly", "biweekly", "monthly"])
+
+    def test_none_findings_handled(self):
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": None, "risk_score": None},
+            scan_history=[],
+        )
+        self.assertIn("recommended_scan_interval", result)
+
+    def test_missing_severity_in_findings(self):
+        result = recommend_scan_interval(
+            "https://example.com",
+            {"findings": [{"title": "no severity field"}]},
+            scan_history=[],
+        )
+        self.assertIn("recommended_scan_interval", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,257 @@
+"""Tests for auto-triage module — finding enrichment and bucketing."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from modules.agent.triage import (
+    _score_business_impact,
+    _score_exploitability,
+    _score_exposure,
+    enrich_findings,
+    generate_triage_buckets,
+    apply_triage,
+)
+
+
+class TestBusinessImpactScoring(unittest.TestCase):
+
+    def test_auth_finding_is_critical(self):
+        finding = {"title": "Broken Authentication", "category": "auth"}
+        level, score = _score_business_impact(finding)
+        self.assertEqual(level, "critical")
+        self.assertEqual(score, 30)
+
+    def test_sqli_finding_is_critical(self):
+        finding = {"title": "SQL Injection on login form", "description": "SQLi detected"}
+        level, score = _score_business_impact(finding)
+        self.assertEqual(level, "critical")
+        self.assertEqual(score, 30)
+
+    def test_payment_finding_is_critical(self):
+        finding = {"title": "Payment endpoint exposed", "category": "payment"}
+        level, _ = _score_business_impact(finding)
+        self.assertEqual(level, "critical")
+
+    def test_xss_finding_is_medium(self):
+        finding = {"title": "Reflected XSS", "category": "xss"}
+        level, score = _score_business_impact(finding)
+        self.assertEqual(level, "medium")
+        self.assertEqual(score, 15)
+
+    def test_cors_finding_is_medium(self):
+        finding = {"title": "CORS Misconfiguration", "category": "cors"}
+        level, _ = _score_business_impact(finding)
+        self.assertEqual(level, "medium")
+
+    def test_generic_info_finding_is_low(self):
+        finding = {"title": "Server banner detected", "severity": "info"}
+        level, score = _score_business_impact(finding)
+        self.assertEqual(level, "low")
+        self.assertEqual(score, 5)
+
+    def test_high_severity_fallback_to_medium(self):
+        finding = {"title": "Unknown issue", "severity": "high"}
+        level, _ = _score_business_impact(finding)
+        self.assertEqual(level, "medium")
+
+    def test_empty_finding(self):
+        level, score = _score_business_impact({})
+        self.assertEqual(level, "low")
+
+
+class TestExploitabilityScoring(unittest.TestCase):
+
+    def test_high_cvss_cve_is_public_exploit(self):
+        finding = {"cve_ids": ["CVE-2024-1234"], "cvss_score": 9.8}
+        level, score = _score_exploitability(finding)
+        self.assertEqual(level, "public_exploit")
+        self.assertEqual(score, 25)
+
+    def test_low_cvss_cve_is_known_cve(self):
+        finding = {"cve_ids": ["CVE-2024-5678"], "cvss_score": 5.0}
+        level, score = _score_exploitability(finding)
+        self.assertEqual(level, "known_cve")
+        self.assertEqual(score, 15)
+
+    def test_exploit_keyword_in_evidence(self):
+        finding = {"evidence": "Public exploit available on Metasploit"}
+        level, _ = _score_exploitability(finding)
+        self.assertEqual(level, "public_exploit")
+
+    def test_exploit_keyword_in_description(self):
+        finding = {"description": "POC demonstrates proof of concept attack"}
+        level, _ = _score_exploitability(finding)
+        self.assertEqual(level, "public_exploit")
+
+    def test_critical_without_cve_is_theoretical(self):
+        finding = {"severity": "critical"}
+        level, score = _score_exploitability(finding)
+        self.assertEqual(level, "theoretical")
+        self.assertEqual(score, 10)
+
+    def test_info_finding_is_low_likelihood(self):
+        finding = {"severity": "info"}
+        level, score = _score_exploitability(finding)
+        self.assertEqual(level, "low_likelihood")
+        self.assertEqual(score, 3)
+
+    def test_empty_finding(self):
+        level, _ = _score_exploitability({})
+        self.assertEqual(level, "low_likelihood")
+
+
+class TestExposureScoring(unittest.TestCase):
+
+    def test_external_url_is_internet_facing(self):
+        finding = {"affected_urls": ["https://example.com/api/users"]}
+        level, score = _score_exposure(finding, None)
+        self.assertEqual(level, "internet_facing")
+        self.assertEqual(score, 10)
+
+    def test_localhost_url_is_internal(self):
+        finding = {"affected_urls": ["http://localhost:8080/test"]}
+        level, _ = _score_exposure(finding, None)
+        self.assertEqual(level, "internal")
+
+    def test_private_ip_is_internal(self):
+        finding = {"affected_urls": ["http://192.168.1.1/admin"]}
+        level, _ = _score_exposure(finding, None)
+        self.assertEqual(level, "internal")
+
+    def test_web_category_defaults_to_internet_facing(self):
+        finding = {"category": "web security"}
+        level, _ = _score_exposure(finding, None)
+        self.assertEqual(level, "internet_facing")
+
+    def test_matching_entry_point(self):
+        finding = {"affected_urls": ["https://app.example.com/api"]}
+        surface = {"entry_points": ["https://app.example.com"]}
+        level, _ = _score_exposure(finding, surface)
+        self.assertEqual(level, "internet_facing")
+
+    def test_empty_finding(self):
+        level, _ = _score_exposure({}, None)
+        self.assertEqual(level, "internal")
+
+
+class TestEnrichFindings(unittest.TestCase):
+
+    def test_enriches_all_fields(self):
+        report = {"findings": [
+            {"title": "SQLi", "severity": "critical", "category": "injection"}
+        ]}
+        enriched = enrich_findings(report)
+        self.assertEqual(len(enriched), 1)
+        f = enriched[0]
+        self.assertIn("exploitability", f)
+        self.assertIn("business_impact", f)
+        self.assertIn("exposure", f)
+        self.assertIn("priority_score", f)
+
+    def test_sorted_by_priority_descending(self):
+        report = {"findings": [
+            {"title": "Info leak", "severity": "info"},
+            {"title": "SQLi on login", "severity": "critical"},
+            {"title": "Missing header", "severity": "medium"},
+        ]}
+        enriched = enrich_findings(report)
+        scores = [f["priority_score"] for f in enriched]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_empty_findings(self):
+        result = enrich_findings({"findings": []})
+        self.assertEqual(result, [])
+
+    def test_none_findings(self):
+        result = enrich_findings({})
+        self.assertEqual(result, [])
+
+    def test_priority_capped_at_100(self):
+        report = {"findings": [
+            {"title": "SQL injection on auth payment credential",
+             "severity": "critical",
+             "cve_ids": ["CVE-2024-9999"],
+             "cvss_score": 10.0,
+             "affected_urls": ["https://pay.example.com"]}
+        ]}
+        enriched = enrich_findings(report)
+        self.assertLessEqual(enriched[0]["priority_score"], 100)
+
+    def test_does_not_mutate_original(self):
+        original = {"title": "Test", "severity": "high"}
+        report = {"findings": [original]}
+        enrich_findings(report)
+        self.assertNotIn("priority_score", original)
+
+
+class TestTriageBuckets(unittest.TestCase):
+
+    def test_critical_goes_to_immediate(self):
+        findings = [{"title": "SQLi", "severity": "critical", "priority_score": 80,
+                      "exploitability": "public_exploit", "business_impact": "critical",
+                      "exposure": "internet_facing"}]
+        buckets = generate_triage_buckets(findings)
+        self.assertEqual(len(buckets["immediate_action"]), 1)
+        self.assertIn("SQLi", buckets["immediate_action"][0])
+
+    def test_high_goes_to_this_sprint(self):
+        findings = [{"title": "Open Redirect", "severity": "high", "priority_score": 50,
+                      "exploitability": "theoretical", "business_impact": "medium",
+                      "exposure": "internet_facing"}]
+        buckets = generate_triage_buckets(findings)
+        self.assertEqual(len(buckets["this_sprint"]), 1)
+
+    def test_low_goes_to_backlog(self):
+        findings = [{"title": "Server Banner", "severity": "info", "priority_score": 10,
+                      "exploitability": "low_likelihood", "business_impact": "low",
+                      "exposure": "internal"}]
+        buckets = generate_triage_buckets(findings)
+        self.assertEqual(len(buckets["backlog"]), 1)
+
+    def test_empty_findings(self):
+        buckets = generate_triage_buckets([])
+        self.assertEqual(buckets["immediate_action"], [])
+        self.assertEqual(buckets["this_sprint"], [])
+        self.assertEqual(buckets["backlog"], [])
+
+    def test_public_exploit_always_immediate(self):
+        findings = [{"title": "Low sev but exploitable", "severity": "low",
+                      "priority_score": 30, "exploitability": "public_exploit",
+                      "business_impact": "low", "exposure": "internal"}]
+        buckets = generate_triage_buckets(findings)
+        self.assertEqual(len(buckets["immediate_action"]), 1)
+
+
+class TestApplyTriage(unittest.TestCase):
+
+    def test_adds_triage_to_report(self):
+        report = {"findings": [
+            {"title": "XSS", "severity": "high"},
+            {"title": "Info", "severity": "info"},
+        ]}
+        result = apply_triage(report)
+        self.assertIn("triage", result)
+        self.assertIn("immediate_action", result["triage"])
+        self.assertIn("this_sprint", result["triage"])
+        self.assertIn("backlog", result["triage"])
+
+    def test_enriches_findings_in_report(self):
+        report = {"findings": [{"title": "Test", "severity": "medium"}]}
+        result = apply_triage(report)
+        self.assertIn("priority_score", result["findings"][0])
+
+    def test_handles_empty_report(self):
+        result = apply_triage({})
+        self.assertIn("triage", result)
+
+    def test_handles_malformed_findings(self):
+        report = {"findings": [{}]}
+        result = apply_triage(report)
+        self.assertIn("triage", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds 64 tests for two critical agent modules that had zero test coverage
- Covers the auto-triage system (issue #7) and scan scheduling logic (issue #7)
- Tests exercise actual production code functions, not just data structures

## Changes
- **`tests/test_triage.py`** — 36 tests covering:
  - `_score_business_impact()`: auth, payment, XSS, CORS, info, empty findings
  - `_score_exploitability()`: CVE+CVSS, exploit keywords, theoretical, low-likelihood
  - `_score_exposure()`: external URLs, localhost, private IPs, entry point matching
  - `enrich_findings()`: field presence, sorting, mutation safety, priority cap at 100
  - `generate_triage_buckets()`: immediate/sprint/backlog routing, public exploit override
  - `apply_triage()`: integration with enrichment, empty/malformed inputs

- **`tests/test_scheduling.py`** — 28 tests covering:
  - `_classify_target_criticality()`: payment, auth, API, app, static, case sensitivity
  - `_compute_change_rate()`: empty, single, stable, volatile, gradual histories
  - `_vulnerability_density()`: empty, single, average
  - `recommend_scan_interval()`: daily/weekly/biweekly/monthly scenarios, volatility, density, edge cases

## Risk Tier
Tier 1 — Test-only change, no production code modified.

## Test plan
- [x] `pytest tests/test_triage.py tests/test_scheduling.py` — 64/64 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)