### PR TITLE
fix: repair broken harness-smoke CI check blocking all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,21 +194,7 @@ jobs:
           ref: ${{ needs.risk-gate.outputs.sha }}
 
       - name: Validate harness.config.json
-        run: |
-          python3 -c "
-          import json, sys
-          config = json.load(open('harness.config.json'))
-          required = ['version', 'riskTiers', 'commands', 'shaDiscipline', 'architecturalBoundaries']
-          missing = [k for k in required if k not in config]
-          if missing:
-              print(f'Missing keys: {", ".join(missing)}', file=sys.stderr)
-              sys.exit(1)
-          for t in ['tier1', 'tier2', 'tier3']:
-              if t not in config['riskTiers']:
-                  print(f'Missing tier: {t}', file=sys.stderr)
-                  sys.exit(1)
-          print(f'harness.config.json schema valid ({len(config[\"riskTiers\"])} tiers)')
-          "
+        run: python3 -c "import json, sys; c = json.load(open('harness.config.json')); req = ['version','riskTiers','commands','shaDiscipline','architecturalBoundaries']; miss = [k for k in req if k not in c]; tiers = [t for t in ['tier1','tier2','tier3'] if t not in c.get('riskTiers',{})]; err = miss + tiers; sys.exit(print('Missing:' + ','.join(err), file=sys.stderr) or 1) if err else print('OK')"
 
       - name: Check CLAUDE.md
         run: |


### PR DESCRIPTION
## Summary
- Fixes the `Harness Smoke = FAILURE` check that was failing on **every PR**
- Root cause: multi-line Python script in `ci.yml` had f-strings with curly braces that bash interpreted, causing `SyntaxError: f-string: expecting a valid expression after '{'`
- Replace with a single-line Python validation that avoids bash/Python quoting conflicts

## Details
The `ci.yml` harness-smoke job (line 196-211) embedded a multi-line Python script containing:
```python
print(f'Missing keys: {", ".join(missing)}', file=sys.stderr)
```
Bash stripped the curly braces before Python could parse the f-string. The fix replaces the multi-line block with a single-line equivalent matching the pattern already used in `harness-smoke.yml`.

## Risk Tier
Tier 2 - CI/CD pipeline change, but the current state is broken (all PRs fail this check).

## Test plan
- [x] Fixed one-liner runs successfully locally
- [ ] This PR's own CI should show Harness Smoke = SUCCESS (self-validating)
- [ ] After merge, existing open PRs should pass when re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)