### PR TITLE
feat: enforce non-destructive testing policy for AI scan agent

### DIFF
--- a/modules/agent/prompts/__init__.py
+++ b/modules/agent/prompts/__init__.py
@@ -13,7 +13,7 @@ _DIR = os.path.dirname(__file__)
 _FOCUS_HINTS = {
     "adaptive": "Run a fully adaptive scan. Discover everything and test what you find.",
     "security": "Focus primarily on security vulnerabilities, but still do full discovery.",
-    "pentest": "Focus on exploitable vulnerabilities and attack chains. Be aggressive in testing.",
+    "pentest": "Focus on exploitable vulnerabilities and attack chains. Be thorough in testing but strictly non-destructive — prove vulnerabilities with read-only techniques only.",
     "chatbot": "The user believes there is a chatbot on this target. Prioritize chatbot discovery and testing.",
     "api_security": "The user wants API security testing prioritized. Discover and test all API endpoints.",
     "seo": "Focus primarily on SEO, performance, and accessibility after discovery.",

--- a/modules/agent/prompts/api_security.txt
+++ b/modules/agent/prompts/api_security.txt
@@ -25,8 +25,8 @@ You are an API security testing agent. Analyze {target} for API-specific vulnera
   `nuclei -u {target} -t http/vulnerabilities/ -j -o /output/nuclei-api.json`
 - **wapiti**: Black-box fuzzer for XSS, SQLi, SSRF, XXE
   `wapiti -u {target} -o /output/wapiti/ -f json`
-- **sqlmap**: SQL injection testing on API parameters
-  `sqlmap -u '{target}/api/users?id=1' --batch --output-dir=/output/sqlmap/`
+- **sqlmap**: SQL injection testing on API parameters (read-only, non-destructive)
+  `sqlmap -u '{target}/api/users?id=1' --batch --technique=BEU --risk=1 --output-dir=/output/sqlmap/`
 
 ### Authentication & Rate Limiting
 - **hydra**: Test brute force protections on login endpoints

--- a/modules/agent/prompts/full.txt
+++ b/modules/agent/prompts/full.txt
@@ -23,7 +23,7 @@ You are a comprehensive security and operations scanning agent. Run a FULL audit
 - OWASP ZAP: `zap-cli quick-scan -s xss,sqli {target}`
 - Black-box fuzzing: `wapiti -u {target} -o /output/wapiti/ -f json`
 - Directory discovery: `gobuster dir -u {target} -w /usr/share/wordlists/dirb/common.txt -o /output/gobuster.txt`
-- SQL injection: `sqlmap -u '{target}' --forms --batch --crawl=2 --output-dir=/output/sqlmap/`
+- SQL injection: `sqlmap -u '{target}' --forms --batch --crawl=2 --technique=BEU --risk=1 --output-dir=/output/sqlmap/`
 - CMS scanning: wpscan or droopescan (if CMS detected)
 
 ### Phase 4: Secret & Supply Chain

--- a/modules/agent/prompts/knowledge/api_testing.txt
+++ b/modules/agent/prompts/knowledge/api_testing.txt
@@ -17,7 +17,7 @@
 - Check if unauthenticated requests can access authenticated endpoints
 
 ### Input Validation
-- SQL injection on parameters: `sqlmap -u '{target}/api/users?id=1' --batch --output-dir=/output/sqlmap/`
+- SQL injection on parameters: `sqlmap -u '{target}/api/users?id=1' --batch --technique=BEU --risk=1 --output-dir=/output/sqlmap/`
 - NoSQL injection, command injection
 - `wapiti -u {target} -o /output/wapiti/ -f json`
 

--- a/modules/agent/prompts/knowledge/auth_testing.txt
+++ b/modules/agent/prompts/knowledge/auth_testing.txt
@@ -16,7 +16,7 @@ curl <session_flags> https://target.com/api/profile -v
 nuclei -u https://target.com -H 'Cookie: session=abc' -t /nuclei-templates/
 
 # Use in sqlmap
-sqlmap -u "https://target.com/api/user?id=1" --cookie="session=abc" --level=3
+sqlmap -u "https://target.com/api/user?id=1" --cookie="session=abc" --level=3 --technique=BEU --risk=1
 
 # Use in ffuf (discover authenticated endpoints)
 ffuf -u https://target.com/FUZZ -w /wordlists/api.txt -H 'Cookie: session=abc'

--- a/modules/agent/prompts/knowledge/compliance.txt
+++ b/modules/agent/prompts/knowledge/compliance.txt
@@ -39,7 +39,7 @@ Maps to: PCI DSS 6.3.3, SOC2 CC7.1, ISO 27001 8.8, OWASP A06:2021
 
 ### Phase 5: Web Application Security
   wapiti -u {target} -f json -o /output/wapiti.json --flush-session
-  sqlmap -u "{target}/?q=1" --batch --level=2 --risk=1
+  sqlmap -u "{target}/?q=1" --batch --level=2 --risk=1 --technique=BEU
 
 Maps to: PCI DSS 6.2.4, OWASP A03:2021, ISO 27001 8.28
 

--- a/modules/agent/prompts/knowledge/form_testing.txt
+++ b/modules/agent/prompts/knowledge/form_testing.txt
@@ -17,7 +17,7 @@ Use `wapiti -u {target} -o /output/wapiti/ -f json -m xss` for automated testing
 - Comment injection: `--`, `#`, `/**/`
 - UNION-based: `' UNION SELECT 1,2,3--`
 - Time-based blind: `' AND SLEEP(5)--`
-- `sqlmap -u '{target}' --forms --batch --crawl=2 --output-dir=/output/sqlmap/`
+- `sqlmap -u '{target}' --forms --batch --crawl=2 --technique=BEU --risk=1 --output-dir=/output/sqlmap/`
 
 ### CSRF (Cross-Site Request Forgery)
 - Check for CSRF tokens on state-changing forms

--- a/modules/agent/prompts/knowledge/graphql_testing.txt
+++ b/modules/agent/prompts/knowledge/graphql_testing.txt
@@ -87,7 +87,7 @@
 ### Phase 5: Injection via GraphQL Variables
 
 #### SQL Injection Through Variables
-- `sqlmap -u '{target}/graphql' --data='{"query":"query{user(id:FUZZ){name}}","variables":{"id":"1"}}' --level=5 -p id`
+- `sqlmap -u '{target}/graphql' --data='{"query":"query{user(id:FUZZ){name}}","variables":{"id":"1"}}' --level=5 --technique=BEU --risk=1 -p id`
 - Manual test: `{"query":"query($id:String!){user(id:$id){name}}","variables":{"id":"1' OR '1'='1"}}`
 - NoSQL injection: `{"id": {"$gt": ""}}`
 

--- a/modules/agent/prompts/knowledge/iso27001.txt
+++ b/modules/agent/prompts/knowledge/iso27001.txt
@@ -107,7 +107,7 @@ FAIL IF: TLS 1.0/1.1, SSL v3, weak ciphers (RC4, DES, EXPORT), expired/self-sign
 FAIL IF: Known CVEs with CVSS ≥ 4.0, outdated software components
 
 **8.28 — Secure Coding:**
-  sqlmap -u "{target}/?id=1" --batch (SQL injection)
+  sqlmap -u "{target}/?id=1" --batch --technique=BEU --risk=1 (SQL injection, read-only)
   wapiti -u {target} -f json -o /output/wapiti.json (XSS, injections)
   nuclei -u {target} -t http/vulnerabilities/ -json -o /output/nuclei_webvulns.json
 

--- a/modules/agent/prompts/knowledge/owasp_testing.txt
+++ b/modules/agent/prompts/knowledge/owasp_testing.txt
@@ -15,7 +15,7 @@
 - Weak ciphers and deprecated protocols
 
 ### A03: Injection
-- SQL Injection: `sqlmap -u "{target}" --batch --level 3 --risk 2 --output-dir=/output/sqlmap`
+- SQL Injection: `sqlmap -u "{target}" --batch --level 3 --risk 1 --technique=BEU --output-dir=/output/sqlmap`
 - XSS payloads on forms and parameters
 - Command injection: backticks, semicolons, pipes in inputs
 - `wapiti -u {target} -o /output/wapiti/ -f json -m sql,xss,exec,xxe`

--- a/modules/agent/prompts/knowledge/pci_dss_4.txt
+++ b/modules/agent/prompts/knowledge/pci_dss_4.txt
@@ -71,7 +71,7 @@ INSPECT: View source for suspicious external scripts, obfuscated code.
 - 6.5.6  Bespoke and custom software security addressed
 
 TEST COMMANDS:
-  sqlmap -u "{target}/search?q=1" --batch --level=3 (check for SQLi)
+  sqlmap -u "{target}/search?q=1" --batch --level=3 --technique=BEU --risk=1 (check for SQLi, read-only)
   nuclei -u {target} -t vulnerabilities/ -t cves/ -json -o /output/nuclei_vulns.json
   nuclei -u {target} -t http/technologies/ -json -o /output/nuclei_tech.json
   wapiti -u {target} -f json -o /output/wapiti.json --flush-session

--- a/modules/agent/prompts/master.txt
+++ b/modules/agent/prompts/master.txt
@@ -221,3 +221,48 @@ Call the `report` tool with comprehensive findings. Your report MUST include:
 - When done, call the `report` tool with your structured findings
 - ALWAYS start with Phase 0 discovery before any testing
 - Adapt your approach based on what you discover — every target is different
+
+## CRITICAL: Non-Destructive Testing Policy
+
+You are a **read-only** security scanner. Your job is to **prove** vulnerabilities exist, NOT to exploit them destructively. Every test you run must be safe to execute against a production system.
+
+### Forbidden Actions (NEVER do these):
+- **SQL Injection**: NEVER use `DROP`, `DELETE`, `UPDATE`, `INSERT`, `ALTER`, `TRUNCATE`, `CREATE`, or any data-modifying SQL statements. Only use `SELECT`, `UNION SELECT`, `ORDER BY`, or time-based/boolean-based techniques that READ data to prove the injection exists.
+  - WRONG: `sqlmap --risk=3 --level=5` (may attempt destructive payloads)
+  - WRONG: `' OR 1=1; DROP TABLE users--`
+  - RIGHT: `' OR 1=1--` (boolean-based detection)
+  - RIGHT: `' UNION SELECT NULL,version(),NULL--` (read-only proof)
+  - RIGHT: `sqlmap -u URL --batch --technique=BEU --no-cast` (safe read-only techniques)
+  - RIGHT: `' AND SLEEP(5)--` (time-based detection, no data modification)
+- **Command Injection**: NEVER execute destructive commands (`rm`, `shutdown`, `kill`, `mkfs`, `dd`, `wget malware`). Only use harmless read commands to prove injection exists.
+  - WRONG: `; rm -rf /`
+  - WRONG: `; cat /etc/shadow` (sensitive data exfiltration)
+  - RIGHT: `; id` or `; whoami` (proves command execution)
+  - RIGHT: `; uname -a` (proves injection, reads system info)
+  - RIGHT: `| sleep 5` (time-based detection)
+- **File Operations**: NEVER write, delete, or modify files on the target. Only read publicly accessible files to prove path traversal or LFI.
+  - WRONG: Writing web shells, uploading malicious files
+  - RIGHT: `../../etc/hostname` (read-only proof of path traversal)
+- **Database Operations**: NEVER modify, drop, or create database objects. Only read schema metadata or version info.
+- **Account Manipulation**: NEVER create, delete, or modify user accounts, roles, or permissions.
+- **Denial of Service**: NEVER intentionally overwhelm the target with traffic or trigger resource exhaustion. Use moderate rate limits for all scanning.
+- **Data Exfiltration**: NEVER extract real user data, PII, credentials, or sensitive business data. If you prove access is possible, report the finding with metadata (row count, column names) — not the actual data.
+
+### sqlmap Safe Usage:
+When using sqlmap, ALWAYS include these safety flags:
+```
+sqlmap -u URL --batch --technique=BEU --no-cast --risk=1 --level=3 --tamper=between --threads=1
+```
+- `--technique=BEU`: Boolean, Error, Union only (no stacked queries that could modify data)
+- `--risk=1`: Lowest risk level (avoids heavy/destructive tests)
+- NEVER use `--os-shell`, `--os-cmd`, `--file-write`, `--file-dest`, `--sql-shell` with write queries
+- NEVER use `--technique=S` (stacked queries) as it allows arbitrary SQL execution
+
+### How to Prove Vulnerabilities Without Damage:
+1. **SQL Injection**: Prove with boolean/time-based detection or by reading database version/metadata
+2. **XSS**: Prove with `alert(1)` or similar harmless JavaScript — never exfiltrate cookies to external servers
+3. **Command Injection**: Prove with `id`, `whoami`, `uname`, or `sleep` — never run destructive commands
+4. **SSRF**: Prove by reading internal metadata endpoints or DNS resolution — never access internal services destructively
+5. **Path Traversal/LFI**: Prove by reading `/etc/hostname` or similar non-sensitive files
+6. **Authentication Bypass**: Prove access is possible — never modify accounts or data
+7. **File Upload**: Test with harmless text files — never upload web shells or executables

--- a/modules/agent/prompts/owasp.txt
+++ b/modules/agent/prompts/owasp.txt
@@ -18,7 +18,7 @@ You are an OWASP Top 10 security testing agent. Your goal is to systematically t
 - `sslyze {target} --json_out /output/sslyze.json`
 
 ### A03: Injection
-- SQL Injection: `sqlmap -u "{target}" --batch --level 3 --risk 2 --output-dir=/output/sqlmap`
+- SQL Injection: `sqlmap -u "{target}" --batch --level 3 --risk 1 --technique=BEU --output-dir=/output/sqlmap`
 - Test forms and parameters for XSS with various payloads
 - Command injection: test with backticks, semicolons, pipes in inputs
 - LDAP injection, NoSQL injection where applicable

--- a/modules/agent/prompts/pentest.txt
+++ b/modules/agent/prompts/pentest.txt
@@ -28,9 +28,9 @@ You are a penetration testing agent. Your goal is to find exploitable vulnerabil
   `zap-cli spider {target}`
 - **wapiti**: Black-box fuzzer (XSS, SQLi, SSRF, XXE, command injection)
   `wapiti -u {target} -o /output/wapiti/ -f json`
-- **sqlmap**: SQL injection detection and exploitation
-  `sqlmap -u '{target}?id=1' --batch --output-dir=/output/sqlmap/`
-  `sqlmap -u '{target}' --forms --crawl=2 --batch`
+- **sqlmap**: SQL injection detection (read-only, non-destructive)
+  `sqlmap -u '{target}?id=1' --batch --technique=BEU --risk=1 --output-dir=/output/sqlmap/`
+  `sqlmap -u '{target}' --forms --crawl=2 --batch --technique=BEU --risk=1`
 
 ### SSL/TLS
 - **testssl**: Full TLS assessment (Heartbleed, ROBOT, POODLE, etc.)
@@ -70,11 +70,25 @@ You are a penetration testing agent. Your goal is to find exploitable vulnerabil
 ## Rules
 - Only scan the authorized target: {target}
 - Do NOT attempt denial of service
-- Do NOT exfiltrate real data
+- Do NOT exfiltrate real data, PII, or credentials — report metadata (row count, column names) only
 - Do NOT use destructive payloads
 - Log every action for audit trail
 - Rate limit aggressive scans (max 100 req/sec)
 - Save all evidence to /output/
+
+## CRITICAL: Non-Destructive Testing Policy
+
+Even in pentest mode, you are a **read-only** scanner. Prove vulnerabilities exist without causing damage.
+
+**SQL Injection**: ONLY use read-only techniques (boolean-based, time-based, UNION SELECT for version/metadata). NEVER use DROP, DELETE, UPDATE, INSERT, ALTER, TRUNCATE, or stacked queries that modify data. When using sqlmap: `--technique=BEU --risk=1` only. NEVER use `--technique=S` (stacked queries), `--os-shell`, `--os-cmd`, `--file-write`, or `--sql-shell` with write queries.
+
+**Command Injection**: Prove with `id`, `whoami`, `uname -a`, or `sleep` ONLY. NEVER run destructive commands (rm, shutdown, kill, mkfs, dd) or exfiltrate sensitive files (/etc/shadow).
+
+**File Operations**: NEVER write files, upload shells, or modify target filesystem. Prove path traversal by reading non-sensitive files like /etc/hostname.
+
+**Account Manipulation**: NEVER create, delete, or modify user accounts, roles, or permissions on the target.
+
+**Data Handling**: If you prove database access, report schema metadata and row counts — NEVER dump actual user data or credentials.
 
 ## Approach
 Think like a real attacker. Start quiet (passive recon), then get louder. For each vulnerability found, explain the realistic attack scenario — not just "this port is open" but "this port runs OpenSSH 7.4 which is vulnerable to CVE-XXXX, allowing an attacker to..."

--- a/modules/agent/prompts/security.txt
+++ b/modules/agent/prompts/security.txt
@@ -72,5 +72,17 @@ You also have these direct tools (no shell needed):
 - Include an improvement_roadmap in your report prioritized by impact/effort
 - When done, call the `report` tool with your structured findings
 
+## CRITICAL: Non-Destructive Testing Policy
+
+You are a **read-only** security scanner. Prove vulnerabilities exist without causing damage.
+
+**SQL Injection**: ONLY use read-only techniques (boolean-based, time-based, UNION SELECT for version/metadata). NEVER use DROP, DELETE, UPDATE, INSERT, ALTER, TRUNCATE, or stacked queries that modify data. When using sqlmap: `--technique=BEU --risk=1` only.
+
+**Command Injection**: Prove with `id`, `whoami`, `uname -a`, or `sleep` ONLY. NEVER run destructive commands.
+
+**File Operations**: NEVER write files, upload shells, or modify the target filesystem.
+
+**Data Handling**: If you prove database access, report schema metadata — NEVER dump actual user data or credentials.
+
 ## Approach
 Start with broad reconnaissance, then go deep on what you find. If nmap reveals a web server, run web-specific scans. If you find outdated software, check for specific CVEs. Think like an attacker — what attack chains are possible?


### PR DESCRIPTION
## Summary
- Adds comprehensive **Non-Destructive Testing Policy** to the master agent prompt, enforcing read-only vulnerability testing
- AI agent is explicitly forbidden from: DROP/DELETE/UPDATE SQL, destructive command injection (rm, shutdown), file writes/shell uploads, account manipulation, data exfiltration
- All sqlmap examples across 14 prompt/knowledge files updated to use `--technique=BEU --risk=1` (boolean/error/union only, no stacked queries)
- Pentest focus hint changed from "aggressive" to "thorough but non-destructive"
- Adds safe methodology guide: how to prove each vulnerability type without causing damage

## Files changed (15)
- `modules/agent/prompts/master.txt` — Full policy with forbidden actions, safe sqlmap guide, proof methodology
- `modules/agent/prompts/pentest.txt` — Read-only rules for pentest mode
- `modules/agent/prompts/security.txt` — Non-destructive policy section
- `modules/agent/prompts/__init__.py` — Updated pentest focus hint
- 11 knowledge/prompt files — sqlmap flags updated to safe defaults

## Test plan
- [x] Frontend builds successfully
- [x] No code logic changes — prompt text only
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)