### PR TITLE
feat: wire posture score into scan completion and register API route (#6)

### DIFF
--- a/modules/api/main.py
+++ b/modules/api/main.py
@@ -7,7 +7,7 @@ from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from modules.api.database import engine, Base
-from modules.api.routes import scans, auth, monitors, schedules, notifications, reports, tools, search, campaigns, dashboard, audit
+from modules.api.routes import scans, auth, monitors, schedules, notifications, reports, tools, search, campaigns, dashboard, audit, posture
 from modules.infra import get_queue
 
 Base.metadata.create_all(bind=engine)
@@ -124,6 +124,7 @@ app.include_router(search.router, prefix="/api/search", tags=["search"])
 app.include_router(campaigns.router, prefix="/api/campaigns", tags=["campaigns"])
 app.include_router(dashboard.router, tags=["dashboard"])
 app.include_router(audit.router, tags=["audit"])
+app.include_router(posture.router, prefix="/api/posture", tags=["posture"])
 
 
 @app.get("/health")

--- a/modules/worker/__init__.py
+++ b/modules/worker/__init__.py
@@ -214,6 +214,15 @@ def main():
                         store_technologies_from_report(scan_id, user_id, target, report, _DB_URL)
                 except Exception as inv_err:
                     log.warning("Asset inventory update failed for scan %s: %s", scan_id, inv_err)
+
+                # Update security posture score after scan completes
+                try:
+                    posture_user_id = _get_scan_user_id(scan_id)
+                    if posture_user_id:
+                        from modules.agent.posture_score import run_posture_update
+                        run_posture_update(scan_id, posture_user_id, target, raw_findings)
+                except Exception as posture_err:
+                    log.warning("Posture score update failed for scan %s: %s", scan_id, posture_err)
             except Exception as e:
                 log.exception("Scan %s failed: %s", scan_id, e)
                 _update_scan_status(scan_id, "failed")


### PR DESCRIPTION
## Summary
- Register the existing posture router at `/api/posture` in `main.py` — the route module was fully implemented but never mounted
- Call `run_posture_update()` in the worker after each scan completes, so posture scores are automatically calculated and stored in ES
- Closes the remaining integration gaps for issue #6

## Risk
**Tier 1** — minimal changes (2 files, 11 lines added), no schema changes, test suite passes (68/68)

## Test plan
- [ ] `python3 -m pytest tests/test_posture_score.py -x` passes all 68 tests
- [ ] API starts with posture route: `GET /api/posture`, `/api/posture/history`, `/api/posture/target/{target}`, `/api/posture/brief`
- [ ] After a scan completes, verify `scanner-security-posture` index receives a new document

🤖 Generated with [Claude Code](https://claude.com/claude-code)