### PR TITLE
feat: wire webhook router and auto-triage/scheduling into scan pipeline (#7, #9)

### DIFF
--- a/modules/agent/scan_agent.py
+++ b/modules/agent/scan_agent.py
@@ -3094,6 +3094,26 @@ def run_scan(scan_id: str, target: str, scan_type: str, config: dict | None = No
     except Exception as exc:
         log.warning("CVSS scoring pass failed: %s", exc)
 
+    # ── Auto-triage findings ──
+    try:
+        from modules.agent.triage import apply_triage
+        apply_triage(report)
+        log.info("Scan %s: auto-triage applied to %d findings", scan_id, len(report.get("findings", [])))
+    except Exception as exc:
+        log.warning("Auto-triage failed for scan %s: %s", scan_id, exc)
+
+    # ── Recommend scan interval ──
+    try:
+        from modules.agent.scheduling import recommend_scan_interval
+        interval_rec = recommend_scan_interval(
+            target=report.get("target", ""),
+            current_report=report,
+        )
+        report["recommended_scan_interval"] = interval_rec
+        log.info("Scan %s: recommended interval = %s", scan_id, interval_rec.get("recommended_scan_interval"))
+    except Exception as exc:
+        log.warning("Scan interval recommendation failed for scan %s: %s", scan_id, exc)
+
     # ── Store report ──
     storage.put_json(f"scans/{scan_id}/report.json", report)
 

--- a/modules/api/main.py
+++ b/modules/api/main.py
@@ -7,7 +7,7 @@ from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from modules.api.database import engine, Base
-from modules.api.routes import scans, auth, monitors, schedules, notifications, reports, tools, search, campaigns, dashboard, audit, posture
+from modules.api.routes import scans, auth, monitors, schedules, notifications, reports, tools, search, campaigns, dashboard, audit, posture, webhooks
 from modules.infra import get_queue
 
 Base.metadata.create_all(bind=engine)
@@ -125,6 +125,7 @@ app.include_router(campaigns.router, prefix="/api/campaigns", tags=["campaigns"]
 app.include_router(dashboard.router, tags=["dashboard"])
 app.include_router(audit.router, tags=["audit"])
 app.include_router(posture.router, prefix="/api/posture", tags=["posture"])
+app.include_router(webhooks.router, prefix="/api/webhooks", tags=["webhooks"])
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- Register webhooks router at `/api/webhooks` — the route module with CI/CD integration, quality gates, and API key auth was fully implemented but never mounted
- Call `apply_triage()` on scan reports to enrich findings with priority scores and bucket them into immediate_action/this_sprint/backlog
- Call `recommend_scan_interval()` to add scheduling recommendations based on target criticality, vulnerability density, and change rate
- Addresses issues #7 (Intelligent Scheduling & Auto-Triage) and #9 (Webhook-Triggered Scanning)

## Risk
**Tier 2** — touches `scan_agent.py` (critical path) but only adds post-processing calls wrapped in try/except, so failures are non-blocking

## Test plan
- [ ] `python3 -m pytest tests/test_triage.py tests/test_scheduling.py -x` passes all 64 tests
- [ ] API starts with webhook routes: `POST /api/webhooks/scan`, `GET /api/webhooks/`
- [ ] After a scan completes, report.json includes `triage` section and `recommended_scan_interval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)