### PR TITLE
fix: correct correlation engine type matching and dedup test mocks

### DIFF
--- a/docs/autodev-log.md
+++ b/docs/autodev-log.md
@@ -14,3 +14,9 @@ Tracks every autonomous development iteration. Each row = one loop cycle.
 | 2026-03-24 | feat/vulnerability-correlation-52 | #52 | PR #83 | Vulnerability correlation engine with attack chain detection |
 | 2026-03-24 | fix/non-destructive-testing-policy | safety | PR #84 | Non-destructive testing policy across all 15 agent prompts |
 | 2026-03-24 | feat/full-dashboard-frontend-85 | #85 | PR #86 | Full multi-page dashboard with 16+ pages and routing |
+| 2026-03-24 | — | PRs #78-81,87-89 | merged | Merged 7 PRs: DOM XSS, webhooks tests, GraphQL tests, triage tests, posture tests, CLAUDE.md, ES fix |
+| 2026-03-24 | fix/wire-posture-score-6 | #6 | PR #90 | Wire posture score calculation into scan completion + register API route |
+| 2026-03-24 | fix/wire-webhooks-and-triage-7-9 | #7, #9 | PR #91 | Wire webhook router, auto-triage, and scheduling recommendations into pipeline |
+| 2026-03-24 | — | PRs #86,90,91 | merged | Merged dashboard, posture score wiring, webhooks/triage wiring |
+| 2026-03-24 | fix/frontend-lint-warnings | lint | PR #92 | Fix all 15 react-hooks/exhaustive-deps warnings across 11 pages |
+| 2026-03-24 | fix/api-input-validation-93 | #93 | PR #94 | Harden API validation: audit Pydantic schema, cron parsing, monitors bounds |

--- a/modules/agent/correlation_engine.py
+++ b/modules/agent/correlation_engine.py
@@ -559,20 +559,21 @@ class ConfidenceScorer:
     @staticmethod
     def _are_related_types(type1: str, type2: str) -> bool:
         """Check if vulnerability types are related."""
-        type1_lower = type1.lower()
-        type2_lower = type2.lower()
-        
-        # Define type relationships
+        # Normalize: lowercase and replace separators with spaces for matching
+        type1_norm = type1.lower().replace("_", " ").replace("-", " ")
+        type2_norm = type2.lower().replace("_", " ").replace("-", " ")
+
+        # Define type relationship groups
         relationships = {
-            "injection": ["sqli", "nosqli", "command_injection", "template_injection"],
-            "access_control": ["idor", "privilege_escalation", "auth_bypass"],
-            "data": ["data_exposure", "info_disclosure", "information_disclosure"],
+            "injection": ["injection", "sqli", "nosqli"],
+            "access_control": ["idor", "privilege escalation", "auth bypass", "access control", "authorization"],
+            "data": ["data exposure", "info disclosure", "information disclosure", "data leak", "sensitive data"],
         }
-        
-        for group, types in relationships.items():
-            if any(t in type1_lower for t in types) and any(t in type2_lower for t in types):
+
+        for group, keywords in relationships.items():
+            if any(k in type1_norm for k in keywords) and any(k in type2_norm for k in keywords):
                 return True
-        
+
         return False
     
     @staticmethod

--- a/tests/test_finding_dedup.py
+++ b/tests/test_finding_dedup.py
@@ -218,7 +218,7 @@ class TestStampAllNew:
 class TestDeduplicateFindings:
     """Test main deduplication workflow."""
 
-    @patch("modules.agent.finding_dedup.es_search")
+    @patch("modules.infra.elasticsearch.search")
     def test_no_previous_findings(self, mock_es_search):
         """When no previous findings exist, all should be marked 'new'."""
         mock_es_search.return_value = {"hits": {"hits": []}}
@@ -232,7 +232,7 @@ class TestDeduplicateFindings:
         assert enriched[0]["finding_status"] == "new"
         assert resolved == []
 
-    @patch("modules.agent.finding_dedup.es_search")
+    @patch("modules.infra.elasticsearch.search")
     def test_existing_finding_still_present(self, mock_es_search):
         """When a previous finding is present in current scan, mark as 'existing'."""
         mock_es_search.return_value = {
@@ -263,7 +263,7 @@ class TestDeduplicateFindings:
         assert enriched[0]["first_seen_scan_id"] == "scan-0"
         assert resolved == []
 
-    @patch("modules.agent.finding_dedup.es_search")
+    @patch("modules.infra.elasticsearch.search")
     def test_finding_regression(self, mock_es_search):
         """When a resolved finding reappears, mark as 'regressed'."""
         mock_es_search.return_value = {
@@ -293,7 +293,7 @@ class TestDeduplicateFindings:
         assert enriched[0]["finding_status"] == "regressed"
         assert resolved == []
 
-    @patch("modules.agent.finding_dedup.es_search")
+    @patch("modules.infra.elasticsearch.search")
     def test_finding_resolution_detection(self, mock_es_search):
         """When a previous finding is not in current scan, mark its ID as resolved."""
         mock_es_search.return_value = {
@@ -332,7 +332,7 @@ class TestDeduplicateFindings:
         assert "prev-doc-1" in resolved
         assert "prev-doc-2" not in resolved
 
-    @patch("modules.agent.finding_dedup.es_search")
+    @patch("modules.infra.elasticsearch.search")
     def test_es_failure_graceful_fallback(self, mock_es_search):
         """When ES search fails, fallback to marking all as 'new'."""
         mock_es_search.side_effect = Exception("ES connection failed")
@@ -350,7 +350,7 @@ class TestDeduplicateFindings:
 class TestMarkResolvedInEs:
     """Test marking findings as resolved in Elasticsearch."""
 
-    @patch("modules.agent.finding_dedup.get_client")
+    @patch("modules.infra.elasticsearch.get_client")
     def test_update_resolved_documents(self, mock_get_client):
         """Should update documents with resolved status."""
         mock_es = MagicMock()
@@ -362,13 +362,13 @@ class TestMarkResolvedInEs:
         assert updated == 2
         assert mock_es.update.call_count == 2
 
-    @patch("modules.agent.finding_dedup.get_client")
+    @patch("modules.infra.elasticsearch.get_client")
     def test_empty_resolved_list(self, mock_get_client):
         """Empty resolved list should return 0."""
         updated = mark_resolved_in_es([], "scan-1", "2024-01-01T00:00:00Z")
         assert updated == 0
 
-    @patch("modules.agent.finding_dedup.get_client")
+    @patch("modules.infra.elasticsearch.get_client")
     def test_update_partial_failure(self, mock_get_client):
         """Should return count of successfully updated docs."""
         mock_es = MagicMock()
@@ -378,7 +378,7 @@ class TestMarkResolvedInEs:
         updated = mark_resolved_in_es(["doc-1", "doc-2", "doc-3"], "scan-1", "2024-01-01T00:00:00Z")
         assert updated == 2  # 2 successes, 1 failure
 
-    @patch("modules.agent.finding_dedup.get_client")
+    @patch("modules.infra.elasticsearch.get_client")
     def test_es_client_failure(self, mock_get_client):
         """ES client initialization failure should return 0."""
         mock_get_client.side_effect = Exception("ES connection failed")


### PR DESCRIPTION
## Summary
- Fix `_are_related_types()` in correlation engine to normalize vulnerability type names (replace `_` and `-` with spaces) so types like `"SQL Injection"` correctly match relationship keywords
- Fix 9 failing tests in `test_finding_dedup.py` by correcting mock paths from `modules.agent.finding_dedup.es_search` → `modules.infra.elasticsearch.search` (and `get_client`), matching where the imports actually originate

## Risk
**Tier 1** — test fixes and minor normalization logic in correlation engine

## Test plan
- [x] All 30 correlation engine tests pass
- [x] All 33 finding dedup tests pass (previously 9 failing)
- [x] 340/344 local tests pass (4 pre-existing failures in exploitation_engine unrelated)
- [x] Frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)