### PR TITLE
feat: add ecommerce scan template to wizard

### DIFF
--- a/docs/autodev-log.md
+++ b/docs/autodev-log.md
@@ -22,3 +22,5 @@ Tracks every autonomous development iteration. Each row = one loop cycle.
 | 2026-03-24 | fix/api-input-validation-93 | #93 | PR #94 merged | Harden API validation: audit Pydantic schema, cron parsing, monitors bounds |
 | 2026-03-24 | fix/correlation-engine-type-matching | test fix | PR #95 merged | Fix correlation engine type matching + 9 dedup test mock paths |
 | 2026-03-24 | feat/ecommerce-ucp-acp-96 | #96 | PR #97 | UCP/ACP commerce protocol scanning for e-commerce sites |
+| 2026-03-24 | fix/exploitation-engine-tests | test fix | PR #98 merged | Fix 4 exploitation engine validation logic bugs |
+| 2026-03-24 | feat/ecommerce-wizard-template | #96 | PR #99 | Add ecommerce scan template to wizard |

--- a/modules/api/scan_wizard.py
+++ b/modules/api/scan_wizard.py
@@ -254,6 +254,25 @@ class ScanTemplates:
                 "detailed_reporting": True,
             }
         ),
+        "ecommerce": ScanTemplateConfig(
+            name="E-Commerce Scan (20 min)",
+            description="Validates UCP/ACP commerce protocols, payment security, PCI-DSS checks, and checkout flow testing.",
+            duration_estimate="20 minutes",
+            enabled_modules=["ssl", "http", "commerce_protocol", "api_testing", "web_vulns", "seo", "performance"],
+            depth="deep",
+            timeout_minutes=20,
+            parallelization=3,
+            config={
+                "scan_type": "ecommerce",
+                "check_ssl": True,
+                "commerce_protocol_validation": True,
+                "payment_security": True,
+                "checkout_flow_testing": True,
+                "pci_dss_checks": True,
+                "seo_audit": True,
+                "performance_check": True,
+            }
+        ),
         "full": ScanTemplateConfig(
             name="Full Audit (60+ min)",
             description="Complete security audit with all modules. Most comprehensive analysis.",


### PR DESCRIPTION
## Summary
- Add "E-Commerce Scan" template to the scan wizard with UCP/ACP commerce protocol validation, payment security, PCI-DSS checks, and SEO/performance auditing
- Complements the `ecommerce` scan type added in PR #97

## Risk
**Tier 1** — adds one entry to the `TEMPLATES` dict, no critical path changes

## Test plan
- [x] `ScanTemplates.list_templates()` returns 6 templates including `ecommerce`
- [x] `ScanTemplates.get_template("ecommerce")` returns correct config with `scan_type: "ecommerce"`
- [x] 344 tests pass, frontend builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)