### PR TITLE
feat: Dark mode toggle with persistent preference

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,8 +7,8 @@ html, body, #root {
   margin: 0;
   padding: 0;
   height: 100%;
-  background: #0f1117;
-  color: #e8eaed;
+  background: var(--app-bg);
+  color: var(--app-text);
 }
 
 .app-layout {
@@ -21,7 +21,7 @@ html, body, #root {
   flex: 1;
   margin-left: 250px;
   overflow-y: auto;
-  background: #0f1117;
+  background: var(--app-bg);
 }
 
 @media (max-width: 768px) {
@@ -40,13 +40,13 @@ html, body, #root {
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  background: #0f1117;
+  background: var(--app-bg);
   padding: 20px;
 }
 
 .login-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   padding: 40px;
   width: 100%;
@@ -67,13 +67,13 @@ html, body, #root {
 .login-header h1 {
   margin: 0 0 8px;
   font-size: 22px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .login-header p {
   margin: 0;
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .login-form {
@@ -83,10 +83,10 @@ html, body, #root {
 }
 
 .login-input {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
   border-radius: 8px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 10px 14px;
   font-size: 14px;
   transition: border-color 0.2s;
@@ -98,8 +98,8 @@ html, body, #root {
 }
 
 .login-error {
-  background: #2a1a1a;
-  border: 1px solid #4a2a2a;
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 6px;
   color: #ff6666;
   padding: 8px 12px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { SecurityAdvisorChat } from './components/SecurityAdvisorChat'
 import { ToastProvider } from './components/ToastContext'
+import ThemeProvider from './contexts/ThemeContext'
 import Toast from './components/Toast'
 import Dashboard from './pages/Dashboard'
 import FindingsPage from './pages/FindingsPage'
@@ -193,19 +194,21 @@ function App() {
   }, [token])
 
   return (
-    <ToastProvider>
-      <Router>
-        {!token ? (
-          <Routes>
-            <Route path="/login" element={<LoginForm onLogin={handleLogin} />} />
-            <Route path="*" element={<Navigate to="/login" replace />} />
-          </Routes>
-        ) : (
-          <AppLayout token={token} onLogout={handleLogout} />
-        )}
-      </Router>
-      <Toast />
-    </ToastProvider>
+    <ThemeProvider>
+      <ToastProvider>
+        <Router>
+          {!token ? (
+            <Routes>
+              <Route path="/login" element={<LoginForm onLogin={handleLogin} />} />
+              <Route path="*" element={<Navigate to="/login" replace />} />
+            </Routes>
+          ) : (
+            <AppLayout token={token} onLogout={handleLogout} />
+          )}
+        </Router>
+        <Toast />
+      </ToastProvider>
+    </ThemeProvider>
   )
 }
 

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -1,7 +1,7 @@
 .sidebar-nav {
   width: 250px;
-  background: #1a1d27;
-  border-right: 1px solid #2a2d3a;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-border);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -14,7 +14,7 @@
 
 .nav-header {
   padding: 20px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--sidebar-border);
 }
 
 .nav-brand {
@@ -41,19 +41,19 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  color: #aaa;
+  color: var(--nav-link-color);
   text-decoration: none;
   transition: all 0.2s;
   cursor: pointer;
 }
 
 .nav-link:hover {
-  background: #252c3a;
+  background: var(--nav-link-hover-bg);
   color: #fff;
 }
 
 .nav-link.active {
-  background: #3a4050;
+  background: var(--nav-active-bg);
   color: #00d4ff;
   border-left: 3px solid #00d4ff;
   padding-left: 13px;
@@ -91,7 +91,27 @@
 
 .nav-footer {
   padding: 16px;
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.theme-toggle-btn {
+  width: 100%;
+  background: transparent;
+  border: 1px solid #3a3d4a;
+  color: #aaa;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s;
+}
+
+.theme-toggle-btn:hover {
+  border-color: #c084fc;
+  color: #c084fc;
 }
 
 .logout-btn {
@@ -120,7 +140,7 @@
     justify-content: space-between;
     position: relative;
     border-right: none;
-    border-bottom: 1px solid #2a2d3a;
+    border-bottom: 1px solid var(--sidebar-border);
   }
 
   .nav-header {
@@ -147,9 +167,16 @@
   .nav-footer {
     padding: 12px 16px;
     border-top: none;
+    flex-direction: row;
   }
 
   .logout-btn {
+    width: auto;
+    padding: 6px 10px;
+    font-size: 11px;
+  }
+
+  .theme-toggle-btn {
     width: auto;
     padding: 6px 10px;
     font-size: 11px;

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -1,8 +1,10 @@
 import { Link, useLocation } from 'react-router-dom'
+import { useTheme } from '../contexts/useTheme'
 import './Navigation.css'
 
 function Navigation({ onLogout }) {
   const location = useLocation()
+  const { theme, toggleTheme } = useTheme()
 
   const navItems = [
     { label: 'Dashboard', path: '/', icon: '📊' },
@@ -50,6 +52,9 @@ function Navigation({ onLogout }) {
       </ul>
 
       <div className="nav-footer">
+        <button onClick={toggleTheme} className="theme-toggle-btn" title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
+          {theme === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode'}
+        </button>
         <button onClick={onLogout} className="logout-btn">
           Sign Out
         </button>

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+import { ThemeContext } from './theme-context'
+
+function getInitialTheme() {
+  const stored = localStorage.getItem('theme')
+  if (stored === 'light' || stored === 'dark') return stored
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+    return 'light'
+  }
+  return 'dark'
+}
+
+export default function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(getInitialTheme)
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  function toggleTheme() {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/frontend/src/contexts/theme-context.js
+++ b/frontend/src/contexts/theme-context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const ThemeContext = createContext(null)

--- a/frontend/src/contexts/useTheme.js
+++ b/frontend/src/contexts/useTheme.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { ThemeContext } from './theme-context'
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within a ThemeProvider')
+  return ctx
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,15 +1,35 @@
 :root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
+  --text: #9ca3af;
+  --text-h: #f3f4f6;
+  --bg: #16171d;
+  --border: #2e303a;
+  --code-bg: #1f2028;
+  --accent: #c084fc;
+  --accent-bg: rgba(192, 132, 252, 0.15);
+  --accent-border: rgba(192, 132, 252, 0.5);
+  --social-bg: rgba(47, 48, 58, 0.5);
   --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+    rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+
+  /* App-level theme tokens (dark defaults) */
+  --app-bg: #0f1117;
+  --app-text: #e8eaed;
+  --app-text-secondary: #888;
+  --app-text-muted: #666;
+  --card-bg: #1a1d27;
+  --card-border: #2a2d3a;
+  --card-hover-bg: #252c3a;
+  --card-hover-border: #3a4050;
+  --input-bg: #0f1117;
+  --input-border: #3a3d4a;
+  --sidebar-bg: #1a1d27;
+  --sidebar-border: #2a2d3a;
+  --nav-link-color: #aaa;
+  --nav-link-hover-bg: #252c3a;
+  --nav-active-bg: #3a4050;
+  --btn-secondary-border: #3a3d4a;
+  --error-bg: #2a1a1a;
+  --error-border: #4a2a2a;
 
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
@@ -30,24 +50,55 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-  }
+[data-theme="dark"] {
+  --text: #9ca3af;
+  --text-h: #f3f4f6;
+  --bg: #16171d;
+  --border: #2e303a;
+  --code-bg: #1f2028;
+  --accent: #c084fc;
+  --accent-bg: rgba(192, 132, 252, 0.15);
+  --accent-border: rgba(192, 132, 252, 0.5);
+  --social-bg: rgba(47, 48, 58, 0.5);
+  --shadow:
+    rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+}
 
-  #social .button-icon {
-    filter: invert(1) brightness(2);
-  }
+[data-theme="dark"] #social .button-icon {
+  filter: invert(1) brightness(2);
+}
+
+[data-theme="light"] {
+  --text: #6b6375;
+  --text-h: #08060d;
+  --bg: #fff;
+  --border: #e5e4e7;
+  --code-bg: #f4f3ec;
+  --accent: #aa3bff;
+  --accent-bg: rgba(170, 59, 255, 0.1);
+  --accent-border: rgba(170, 59, 255, 0.5);
+  --social-bg: rgba(244, 243, 236, 0.5);
+  --shadow:
+    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+
+  --app-bg: #f5f6fa;
+  --app-text: #1a1d27;
+  --app-text-secondary: #6b7280;
+  --app-text-muted: #9ca3af;
+  --card-bg: #ffffff;
+  --card-border: #e2e4e9;
+  --card-hover-bg: #f0f1f5;
+  --card-hover-border: #c8cad0;
+  --input-bg: #ffffff;
+  --input-border: #d1d5db;
+  --sidebar-bg: #1e2130;
+  --sidebar-border: #2a2d3a;
+  --nav-link-color: #b0b4c0;
+  --nav-link-hover-bg: #2a2f40;
+  --nav-active-bg: #3a4050;
+  --btn-secondary-border: #d1d5db;
+  --error-bg: #fef2f2;
+  --error-border: #fecaca;
 }
 
 body {

--- a/frontend/src/pages/Common.css
+++ b/frontend/src/pages/Common.css
@@ -14,25 +14,25 @@
   margin: 0 0 8px;
   font-size: 32px;
   font-weight: 700;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .page-header p {
   margin: 0;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .loading {
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 14px;
 }
 
 .error-message {
-  background: #2a1a1a;
-  border: 1px solid #4a2a2a;
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 8px;
   color: #ff6666;
   padding: 12px 16px;
@@ -43,7 +43,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 14px;
 }
 
@@ -59,8 +59,8 @@
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   flex: 1;
   max-width: 200px;
@@ -68,7 +68,7 @@
 
 .summary-item .label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -76,15 +76,15 @@
 .summary-item .count {
   font-size: 24px;
   font-weight: 700;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .webhooks-list,
 .schedules-list {
   margin-top: 40px;
   padding: 20px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
 }
 
@@ -92,5 +92,5 @@
 .schedules-list h2 {
   margin: 0 0 16px;
   font-size: 16px;
-  color: #fff;
+  color: var(--app-text);
 }

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -12,24 +12,24 @@
   margin: 0 0 8px;
   font-size: 28px;
   font-weight: 700;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .page-header p {
   margin: 0;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .loading {
   text-align: center;
   padding: 40px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .error-message {
-  background: #2a1a1a;
-  border: 1px solid #4a2a2a;
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 8px;
   color: #ff6666;
   padding: 12px 16px;
@@ -45,16 +45,16 @@
 }
 
 .stat-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 20px;
   transition: all 0.2s;
 }
 
 .stat-card:hover {
-  border-color: #3a4050;
-  background: #252c3a;
+  border-color: var(--card-hover-border);
+  background: var(--card-hover-bg);
 }
 
 .stat-card.critical {
@@ -71,7 +71,7 @@
 
 .stat-label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   margin-bottom: 8px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -80,7 +80,7 @@
 .stat-value {
   font-size: 32px;
   font-weight: 700;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .recent-scans {
@@ -91,7 +91,7 @@
   margin: 0 0 16px;
   font-size: 18px;
   font-weight: 600;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .scans-list {
@@ -101,8 +101,8 @@
 }
 
 .scan-item {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 16px;
   transition: all 0.2s;
@@ -110,14 +110,14 @@
 }
 
 .scan-item:hover {
-  border-color: #3a4050;
-  background: #252c3a;
+  border-color: var(--card-hover-border);
+  background: var(--card-hover-bg);
 }
 
 .scan-title {
   font-size: 14px;
   font-weight: 600;
-  color: #fff;
+  color: var(--app-text);
   margin-bottom: 8px;
 }
 
@@ -125,7 +125,7 @@
   display: flex;
   gap: 12px;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .status {
@@ -147,13 +147,13 @@
 }
 
 .timestamp {
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .empty-state {
   text-align: center;
   padding: 40px;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 14px;
 }
 
@@ -171,7 +171,7 @@
 
 .last-updated {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
   white-space: nowrap;
 }
 
@@ -180,10 +180,10 @@
   align-items: center;
   gap: 6px;
   padding: 8px 14px;
-  background: #1a1d27;
-  border: 1px solid #3a3d4a;
+  background: var(--card-bg);
+  border: 1px solid var(--btn-secondary-border);
   border-radius: 6px;
-  color: #aaa;
+  color: var(--nav-link-color);
   font-size: 13px;
   cursor: pointer;
   transition: all 0.2s;
@@ -219,8 +219,8 @@
   align-items: center;
   justify-content: center;
   padding: 60px 24px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   text-align: center;
 }
@@ -234,13 +234,13 @@
   margin: 0 0 8px;
   font-size: 18px;
   font-weight: 600;
-  color: #ccc;
+  color: var(--app-text);
 }
 
 .empty-state-text {
   margin: 0 0 24px;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
   max-width: 400px;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- Add `ThemeProvider` context with `useTheme` hook for dark/light mode switching
- Theme initializes from `localStorage`, falls back to OS `prefers-color-scheme`
- Persist preference to `localStorage` and apply `data-theme` attribute on `<html>`
- Add sun/moon toggle button in sidebar navigation footer
- Replace hardcoded dark colors with CSS custom properties in `index.css`, `App.css`, `Navigation.css`, `Common.css`, and `Dashboard.css`
- Define light theme variable overrides via `[data-theme="light"]` selector

Closes #107

**Risk Tier: Tier 1** - Frontend-only UI change, no backend or security-critical paths affected.

## Test plan
- [x] `npm run build` passes with zero errors
- [x] `npm run lint` passes with zero errors and no new warnings
- [ ] Verify dark mode is the default appearance (matches existing look)
- [ ] Click toggle button in sidebar footer to switch to light mode
- [ ] Verify light mode applies correct colors to cards, backgrounds, text, inputs
- [ ] Refresh page and verify preference persists via localStorage
- [ ] Clear localStorage and verify OS preference is respected as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)