### PR TITLE
fix: complete dark mode CSS variable migration

### DIFF
--- a/frontend/src/components/FindingDetailModal.css
+++ b/frontend/src/components/FindingDetailModal.css
@@ -17,8 +17,8 @@
 }
 
 .fdm-modal {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   width: 100%;
   max-width: 720px;
@@ -37,8 +37,8 @@
 /* Header */
 .fdm-header {
   padding: 20px 24px 16px;
-  border-bottom: 1px solid #2a2d3a;
-  border-top: 3px solid #888;
+  border-bottom: 1px solid var(--card-border);
+  border-top: 3px solid var(--app-text-secondary);
   border-radius: 12px 12px 0 0;
 }
 
@@ -64,13 +64,13 @@
 .fdm-severity-pill.medium { background: #4a4a2a; color: #ffaa44; }
 .fdm-severity-pill.low { background: #2a4a2a; color: #44ff44; }
 .fdm-severity-pill.info { background: #2a3a4a; color: #4a9eff; }
-.fdm-severity-pill.unknown { background: #2a2d3a; color: #888; }
+.fdm-severity-pill.unknown { background: var(--card-border); color: var(--app-text-secondary); }
 
 .fdm-cvss {
   font-size: 12px;
   font-weight: 700;
-  color: #e8eaed;
-  background: #111420;
+  color: var(--app-text);
+  background: var(--app-bg);
   padding: 3px 10px;
   border-radius: 4px;
   font-family: 'Fira Code', monospace;
@@ -80,7 +80,7 @@
   margin-left: auto;
   background: none;
   border: none;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 24px;
   cursor: pointer;
   padding: 0 4px;
@@ -93,7 +93,7 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #e8eaed;
+  color: var(--app-text);
   line-height: 1.4;
 }
 
@@ -110,7 +110,7 @@
   border-radius: 3px;
   font-size: 11px;
   font-weight: 500;
-  background: #252c3a;
+  background: var(--card-hover-bg);
   color: #94a3b8;
   border: 1px solid #334155;
 }
@@ -164,8 +164,8 @@
 
 .fdm-code {
   display: block;
-  background: #0f1117;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   padding: 12px 16px;
   font-family: 'Fira Code', 'Courier New', monospace;
@@ -179,8 +179,8 @@
 
 .fdm-url {
   display: block;
-  background: #0f1117;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 4px;
   padding: 8px 12px;
   font-family: 'Fira Code', monospace;
@@ -221,7 +221,7 @@
   flex-direction: column;
   gap: 4px;
   padding: 8px 12px;
-  background: #111420;
+  background: var(--app-bg);
   border-radius: 6px;
   border: 1px solid #1e2433;
 }
@@ -272,7 +272,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
-  background: #111420;
+  background: var(--app-bg);
   border-radius: 4px;
   font-size: 12px;
 }
@@ -291,7 +291,7 @@
   display: flex;
   justify-content: flex-end;
   padding: 12px 24px;
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--card-border);
 }
 
 .fdm-btn {
@@ -305,7 +305,7 @@
 }
 
 .fdm-btn-close {
-  background: #252c3a;
+  background: var(--card-hover-bg);
   color: #94a3b8;
   border: 1px solid #334155;
 }

--- a/frontend/src/components/LoadingSkeleton.css
+++ b/frontend/src/components/LoadingSkeleton.css
@@ -1,5 +1,5 @@
 .skeleton-table {
-  border: 1px solid #2a2d3a;
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -9,8 +9,8 @@
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 16px;
   padding: 12px 16px;
-  background: #1a1d27;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--card-border);
 }
 
 .skeleton-row {
@@ -27,7 +27,7 @@
 
 .skeleton-cell {
   height: 14px;
-  background: #2a2d3a;
+  background: var(--card-border);
   border-radius: 4px;
 }
 

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -26,7 +26,7 @@
 
 .nav-subtitle {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .nav-menu {
@@ -76,7 +76,7 @@
   display: block;
   text-align: center;
   background: #00d4ff;
-  color: #1a1d27;
+  color: var(--card-bg);
   font-weight: 600;
   font-size: 14px;
   padding: 10px 16px;
@@ -100,8 +100,8 @@
 .theme-toggle-btn {
   width: 100%;
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #aaa;
+  border: 1px solid var(--input-border);
+  color: var(--nav-link-color);
   padding: 8px 12px;
   border-radius: 6px;
   cursor: pointer;
@@ -117,8 +117,8 @@
 .logout-btn {
   width: 100%;
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #aaa;
+  border: 1px solid var(--input-border);
+  color: var(--nav-link-color);
   padding: 8px 12px;
   border-radius: 6px;
   cursor: pointer;

--- a/frontend/src/components/Pagination.css
+++ b/frontend/src/components/Pagination.css
@@ -6,8 +6,8 @@
   gap: 12px;
   margin-top: 16px;
   padding: 12px 16px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
 }
 
@@ -16,7 +16,7 @@
   align-items: center;
   gap: 16px;
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .pagination-size {
@@ -27,14 +27,14 @@
 
 .pagination-size label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .pagination-size select {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 4px 8px;
   font-size: 13px;
   cursor: pointer;
@@ -52,10 +52,10 @@
 }
 
 .pagination-btn {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 6px 12px;
   font-size: 13px;
   cursor: pointer;
@@ -64,7 +64,7 @@
 
 .pagination-btn:hover:not(:disabled) {
   border-color: #4a9eff;
-  background: #1a1d27;
+  background: var(--card-bg);
 }
 
 .pagination-btn:disabled {
@@ -86,7 +86,7 @@
 }
 
 .pagination-ellipsis {
-  color: #666;
+  color: var(--app-text-muted);
   padding: 0 4px;
   font-size: 14px;
 }

--- a/frontend/src/components/SearchModal.css
+++ b/frontend/src/components/SearchModal.css
@@ -11,8 +11,8 @@
 }
 
 .search-modal {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   width: 100%;
   max-width: 640px;
@@ -39,12 +39,12 @@
   align-items: center;
   gap: 12px;
   padding: 16px 20px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .search-modal-icon {
   flex-shrink: 0;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .search-modal-input {
@@ -52,20 +52,20 @@
   background: transparent;
   border: none;
   outline: none;
-  color: #e8eaed;
+  color: var(--app-text);
   font-size: 16px;
   font-family: inherit;
 }
 
 .search-modal-input::placeholder {
-  color: #555;
+  color: var(--app-text-muted);
 }
 
 .search-modal-kbd {
   font-size: 11px;
-  color: #555;
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  color: var(--app-text-muted);
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 4px;
   padding: 2px 6px;
   font-family: monospace;
@@ -82,7 +82,7 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 14px;
 }
 
@@ -91,7 +91,7 @@
   flex-direction: column;
   align-items: center;
   padding: 32px;
-  color: #555;
+  color: var(--app-text-muted);
   font-size: 14px;
   text-align: center;
 }
@@ -99,7 +99,7 @@
 .search-modal-empty-hint {
   margin-top: 8px;
   font-size: 12px;
-  color: #444;
+  color: var(--app-text-muted);
 }
 
 .search-modal-section {
@@ -113,13 +113,13 @@
   padding: 8px 20px 4px;
   font-size: 11px;
   font-weight: 600;
-  color: #666;
+  color: var(--app-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .search-modal-section-count {
-  color: #444;
+  color: var(--app-text-muted);
   font-weight: 400;
 }
 
@@ -136,7 +136,7 @@
 
 .search-modal-result:hover,
 .search-modal-result.active {
-  background: #252c3a;
+  background: var(--card-hover-bg);
 }
 
 .search-modal-result-icon {
@@ -167,7 +167,7 @@
 
 .search-modal-result-title {
   font-size: 14px;
-  color: #e8eaed;
+  color: var(--app-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -175,7 +175,7 @@
 
 .search-modal-result-meta {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -222,9 +222,9 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 20px;
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--card-border);
   font-size: 11px;
-  color: #555;
+  color: var(--app-text-muted);
 }
 
 .search-modal-footer-keys {
@@ -240,8 +240,8 @@
 }
 
 .search-modal-footer-key kbd {
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 3px;
   padding: 1px 5px;
   font-family: monospace;

--- a/frontend/src/components/SecurityAdvisorChat.css
+++ b/frontend/src/components/SecurityAdvisorChat.css
@@ -7,8 +7,8 @@
   max-width: 900px;
   margin: 0 auto;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #0f1117;
-  color: #e8eaed;
+  background: var(--app-bg);
+  color: var(--app-text);
 }
 
 /* Header */
@@ -17,8 +17,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: #1a1d27;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--card-border);
   flex-shrink: 0;
 }
 
@@ -36,19 +36,19 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .advisor-title p {
   margin: 2px 0 0;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .clear-btn {
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #888;
+  border: 1px solid var(--input-border);
+  color: var(--app-text-secondary);
   padding: 6px 12px;
   border-radius: 6px;
   cursor: pointer;
@@ -80,7 +80,7 @@
 }
 
 .messages-container::-webkit-scrollbar-thumb {
-  background: #3a3d4a;
+  background: var(--input-border);
   border-radius: 2px;
 }
 
@@ -92,7 +92,7 @@
   text-align: center;
   padding: 40px 20px;
   gap: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .empty-icon {
@@ -101,7 +101,7 @@
 
 .empty-state h3 {
   margin: 0;
-  color: #c8cacd;
+  color: var(--app-text);
   font-size: 18px;
 }
 
@@ -120,9 +120,9 @@
 }
 
 .suggestion-btn {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
-  color: #aaa;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  color: var(--nav-link-color);
   padding: 10px 16px;
   border-radius: 8px;
   cursor: pointer;
@@ -179,17 +179,17 @@
 }
 
 .message-agent .message-text {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 4px 12px 12px 12px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .message-user .message-text {
   background: #1a3a6e;
   border: 1px solid #2a4a8e;
   border-radius: 12px 4px 12px 12px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .message-alert .message-text {
@@ -200,7 +200,7 @@
 
 .message-time {
   font-size: 11px;
-  color: #555;
+  color: var(--app-text-muted);
   padding: 0 4px;
 }
 
@@ -218,8 +218,8 @@
   justify-content: space-between;
   gap: 12px;
   padding: 8px 12px;
-  background: #0f1117;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   font-size: 13px;
 }
@@ -236,7 +236,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #aaa;
+  color: var(--nav-link-color);
   flex: 1;
 }
 
@@ -263,7 +263,7 @@
 
 .action-status {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   flex-shrink: 0;
 }
 
@@ -280,8 +280,8 @@
   display: flex;
   gap: 4px;
   padding: 12px 16px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 4px 12px 12px 12px;
 }
 
@@ -311,17 +311,17 @@
   display: flex;
   gap: 10px;
   padding: 16px 20px;
-  background: #1a1d27;
-  border-top: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border-top: 1px solid var(--card-border);
   flex-shrink: 0;
 }
 
 .chat-input {
   flex: 1;
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 8px;
-  color: #e8eaed;
+  color: var(--app-text);
   font-size: 14px;
   padding: 10px 14px;
   resize: none;

--- a/frontend/src/pages/AssetsPage.css
+++ b/frontend/src/pages/AssetsPage.css
@@ -1,6 +1,6 @@
 .assets-summary {
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
   margin-bottom: 16px;
 }
 
@@ -11,33 +11,33 @@
 .assets-table table {
   width: 100%;
   border-collapse: collapse;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   overflow: hidden;
 }
 
 .assets-table th {
-  background: #111420;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .assets-table td {
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .asset-row:hover {
-  background: #252c3a;
+  background: var(--card-hover-bg);
 }
 
 .asset-row.asset-new {
@@ -60,12 +60,12 @@
 .mono-cell {
   font-family: monospace;
   font-size: 12px;
-  color: #aaa;
+  color: var(--nav-link-color);
 }
 
 .date-cell {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   white-space: nowrap;
 }
 

--- a/frontend/src/pages/CampaignsPage.css
+++ b/frontend/src/pages/CampaignsPage.css
@@ -5,8 +5,8 @@
 }
 
 .campaign-form {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 20px;
   margin-bottom: 24px;
@@ -23,7 +23,7 @@
 
 .campaign-form .form-group label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -31,10 +31,10 @@
 .campaign-form input,
 .campaign-form textarea,
 .campaign-form select {
-  background: #12141c;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 10px 12px;
   font-size: 13px;
   font-family: inherit;
@@ -55,14 +55,14 @@
 }
 
 .campaign-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   transition: all 0.2s;
 }
 
 .campaign-card:hover {
-  border-color: #3a4050;
+  border-color: var(--card-hover-border);
 }
 
 .campaign-header {
@@ -90,7 +90,7 @@
 
 .meta-text {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .campaign-actions {
@@ -102,18 +102,18 @@
 
 .expand-icon {
   font-size: 14px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .campaign-details {
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--card-border);
   padding: 16px 20px;
 }
 
 .campaign-details h4 {
   margin: 0 0 12px;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -127,16 +127,16 @@
   text-align: left;
   padding: 8px 12px;
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .campaign-details td {
   padding: 10px 12px;
   font-size: 13px;
-  color: #ccc;
+  color: var(--app-text);
   border-bottom: 1px solid #1e2130;
 }
 
@@ -147,13 +147,13 @@
 
 .empty-cell {
   text-align: center;
-  color: #666;
+  color: var(--app-text-muted);
   padding: 24px 12px;
 }
 
 .campaign-report {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   margin-bottom: 24px;
   overflow: hidden;
@@ -164,7 +164,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .report-header-bar h3 {
@@ -180,7 +180,7 @@
 
 .report-summary {
   font-size: 14px;
-  color: #ccc;
+  color: var(--app-text);
   line-height: 1.6;
   margin: 0 0 16px;
 }
@@ -192,7 +192,7 @@
 .report-section h4 {
   margin: 0 0 8px;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -208,9 +208,9 @@
 
 .report-findings-list li {
   font-size: 13px;
-  color: #ccc;
+  color: var(--app-text);
   padding: 6px 10px;
-  background: #12141c;
+  background: var(--app-bg);
   border-radius: 4px;
 }
 
@@ -225,13 +225,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
-  background: #12141c;
+  background: var(--app-bg);
   border-radius: 4px;
 }
 
 .risk-target {
   font-size: 13px;
-  color: #ccc;
+  color: var(--app-text);
   word-break: break-all;
 }
 
@@ -244,11 +244,11 @@
 }
 
 .report-raw {
-  background: #12141c;
+  background: var(--app-bg);
   border-radius: 4px;
   padding: 16px;
   font-size: 12px;
-  color: #aaa;
+  color: var(--nav-link-color);
   overflow-x: auto;
   margin: 0;
 }
@@ -269,7 +269,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .empty-state p {

--- a/frontend/src/pages/CompliancePage.css
+++ b/frontend/src/pages/CompliancePage.css
@@ -7,8 +7,8 @@
   margin-bottom: 28px;
   flex-wrap: wrap;
   padding: 20px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
 }
 
@@ -22,15 +22,15 @@
 
 .control-group label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .control-group select {
-  background: #12141c;
-  border: 1px solid #2a2d3a;
-  color: #e8eaed;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
+  color: var(--app-text);
   padding: 10px 12px;
   border-radius: 6px;
   font-size: 13px;
@@ -44,7 +44,7 @@
 
 .control-hint {
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   font-style: italic;
 }
 
@@ -67,8 +67,8 @@
 }
 
 .score-section {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 24px;
 }
@@ -88,7 +88,7 @@
 
 .framework-version {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
   background: #252830;
   padding: 2px 8px;
   border-radius: 4px;
@@ -163,8 +163,8 @@
 /* Controls Table */
 
 .controls-list {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 24px;
 }
@@ -184,10 +184,10 @@
   text-align: left;
   padding: 10px 12px;
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .controls-table td {
@@ -205,13 +205,13 @@
 }
 
 .control-name {
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .control-id {
   display: inline-block;
   font-weight: 700;
-  color: #aaa;
+  color: var(--nav-link-color);
   margin-right: 8px;
   min-width: 36px;
 }
@@ -246,7 +246,7 @@
 }
 
 .findings-count .no-findings {
-  color: #555;
+  color: var(--app-text-muted);
 }
 
 /* Frameworks Overview Grid */
@@ -268,8 +268,8 @@
 }
 
 .framework-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 20px;
   cursor: pointer;
@@ -289,7 +289,7 @@
 
 .fw-version {
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   background: #252830;
   padding: 2px 8px;
   border-radius: 4px;
@@ -298,6 +298,6 @@
 .fw-description {
   margin: 12px 0 0;
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
   line-height: 1.5;
 }

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -199,7 +199,7 @@
 .dashboard-new-scan {
   display: inline-block;
   background: #00d4ff;
-  color: #1a1d27;
+  color: var(--card-bg);
   font-weight: 600;
   font-size: 14px;
   padding: 10px 20px;

--- a/frontend/src/pages/FindingsPage.css
+++ b/frontend/src/pages/FindingsPage.css
@@ -27,8 +27,8 @@
   gap: 16px;
   margin-bottom: 24px;
   padding: 16px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
 }
 
@@ -40,7 +40,7 @@
 
 .filter-group label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
@@ -48,10 +48,10 @@
 
 .filter-group select,
 .filter-group input {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 8px 12px;
   font-size: 13px;
   transition: border-color 0.2s;
@@ -74,12 +74,12 @@
 }
 
 .cvss-range span {
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .findings-summary {
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
   margin-bottom: 16px;
 }
 
@@ -90,33 +90,33 @@
 .findings-table table {
   width: 100%;
   border-collapse: collapse;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   overflow: hidden;
 }
 
 .findings-table th {
-  background: #111420;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .findings-table td {
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .finding-row:hover {
-  background: #252c3a;
+  background: var(--card-hover-bg);
 }
 
 .title-cell {
@@ -203,10 +203,10 @@
 }
 
 .status-select {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 4px 8px;
   font-size: 12px;
   cursor: pointer;
@@ -229,8 +229,8 @@
   top: 100%;
   left: 0;
   z-index: 100;
-  background: #1a1d27;
-  border: 1px solid #3a3d4a;
+  background: var(--card-bg);
+  border: 1px solid var(--input-border);
   border-radius: 8px;
   padding: 12px;
   margin-top: 4px;
@@ -241,16 +241,16 @@
 .reason-popover label {
   display: block;
   font-size: 12px;
-  color: #aaa;
+  color: var(--nav-link-color);
   margin-bottom: 8px;
 }
 
 .reason-popover textarea {
   width: 100%;
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 8px;
   font-size: 13px;
   resize: vertical;
@@ -307,12 +307,12 @@
 
 .toggle-text {
   font-size: 13px;
-  color: #aaa;
+  color: var(--nav-link-color);
   white-space: nowrap;
 }
 
 .scan-ref {
-  color: #666;
+  color: var(--app-text-muted);
   font-family: monospace;
   font-size: 12px;
 }
@@ -335,7 +335,7 @@
 
 .empty-cell {
   text-align: center;
-  color: #666;
+  color: var(--app-text-muted);
   padding: 40px !important;
 }
 
@@ -352,8 +352,8 @@
 }
 
 .modal-content {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   max-width: 600px;
   width: 100%;
@@ -367,7 +367,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 20px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .modal-header h2 {
@@ -379,7 +379,7 @@
 .close-btn {
   background: transparent;
   border: none;
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 20px;
   cursor: pointer;
   transition: color 0.2s;
@@ -402,7 +402,7 @@
 .detail-section h3 {
   margin: 0 0 12px;
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
@@ -411,7 +411,7 @@
 .detail-section p {
   margin: 0;
   font-size: 13px;
-  color: #aaa;
+  color: var(--nav-link-color);
   line-height: 1.6;
 }
 
@@ -452,7 +452,7 @@
 
 .cvss-vector {
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   font-family: monospace;
 }
 
@@ -466,13 +466,13 @@
   display: flex;
   justify-content: space-between;
   padding: 8px;
-  background: #111420;
+  background: var(--app-bg);
   border-radius: 4px;
   font-size: 12px;
 }
 
 .history-date {
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .history-status {
@@ -484,7 +484,7 @@
   display: flex;
   gap: 12px;
   padding: 16px 20px;
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--card-border);
 }
 
 .btn {
@@ -500,8 +500,8 @@
 
 .btn-secondary {
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #aaa;
+  border: 1px solid var(--input-border);
+  color: var(--nav-link-color);
 }
 
 .btn-secondary:hover {
@@ -553,8 +553,8 @@
   align-items: center;
   justify-content: center;
   padding: 60px 24px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   text-align: center;
 }
@@ -568,13 +568,13 @@
   margin: 0 0 8px;
   font-size: 18px;
   font-weight: 600;
-  color: #ccc;
+  color: var(--app-text);
 }
 
 .empty-state-text {
   margin: 0 0 24px;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
   max-width: 400px;
   line-height: 1.5;
 }
@@ -620,8 +620,8 @@
 
 .btn-save-filter {
   background: transparent;
-  border: 1px dashed #3a3d4a;
-  color: #888;
+  border: 1px dashed var(--input-border);
+  color: var(--app-text-secondary);
   padding: 6px 14px;
   border-radius: 6px;
   cursor: pointer;
@@ -641,10 +641,10 @@
 }
 
 .save-filter-input {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 6px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 6px 10px;
   font-size: 12px;
   width: 180px;
@@ -678,8 +678,8 @@
 
 .btn-save-cancel {
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #888;
+  border: 1px solid var(--input-border);
+  color: var(--app-text-secondary);
   padding: 6px 12px;
   border-radius: 6px;
   cursor: pointer;
@@ -688,8 +688,8 @@
 }
 
 .btn-save-cancel:hover {
-  border-color: #666;
-  color: #aaa;
+  border-color: var(--app-text-muted);
+  color: var(--nav-link-color);
 }
 
 .saved-filters-list {
@@ -701,15 +701,15 @@
 
 .saved-filters-label {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
   font-weight: 600;
 }
 
 .saved-filter-chip {
   display: flex;
   align-items: center;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -731,8 +731,8 @@
 .saved-filter-chip-delete {
   background: transparent;
   border: none;
-  border-left: 1px solid #2a2d3a;
-  color: #666;
+  border-left: 1px solid var(--card-border);
+  color: var(--app-text-muted);
   padding: 4px 8px;
   cursor: pointer;
   font-size: 11px;

--- a/frontend/src/pages/InventoryPage.css
+++ b/frontend/src/pages/InventoryPage.css
@@ -3,7 +3,7 @@
   display: flex;
   gap: 4px;
   margin-bottom: 24px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding-bottom: 0;
 }
 
@@ -11,7 +11,7 @@
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #888;
+  color: var(--app-text-secondary);
   padding: 10px 20px;
   font-size: 14px;
   font-weight: 600;
@@ -20,7 +20,7 @@
 }
 
 .tab-btn:hover {
-  color: #ccc;
+  color: var(--app-text);
 }
 
 .tab-btn.active {
@@ -35,7 +35,7 @@
 
 .inventory-summary {
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
   margin-bottom: 16px;
 }
 
@@ -46,34 +46,34 @@
 .inventory-table table {
   width: 100%;
   border-collapse: collapse;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   overflow: hidden;
 }
 
 .inventory-table th {
-  background: #111420;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .inventory-table td {
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .tech-row:hover,
 .cve-row:hover {
-  background: #252c3a;
+  background: var(--card-hover-bg);
 }
 
 .tech-name {

--- a/frontend/src/pages/PosturePage.css
+++ b/frontend/src/pages/PosturePage.css
@@ -27,7 +27,7 @@
 
 .posture-score-label {
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 1px;
   margin-bottom: 8px;
@@ -54,7 +54,7 @@
 
 .posture-score-range {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
   margin-top: 4px;
 }
 
@@ -72,7 +72,7 @@
 }
 
 .trend-stable {
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .trend-degrading {
@@ -157,7 +157,7 @@
 
 .target-findings {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .brief-section {
@@ -175,7 +175,7 @@
   border: 1px solid #333;
   border-radius: 8px;
   padding: 20px;
-  color: #ccc;
+  color: var(--app-text);
   line-height: 1.6;
 }
 

--- a/frontend/src/pages/RemediationPage.css
+++ b/frontend/src/pages/RemediationPage.css
@@ -22,8 +22,8 @@
   display: flex;
   gap: 4px;
   margin-bottom: 24px;
-  background: #12141c;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 4px;
   width: fit-content;
@@ -32,7 +32,7 @@
 .tab-btn {
   background: transparent;
   border: none;
-  color: #888;
+  color: var(--app-text-secondary);
   padding: 8px 20px;
   border-radius: 6px;
   cursor: pointer;
@@ -42,7 +42,7 @@
 }
 
 .tab-btn:hover {
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .tab-btn.active {
@@ -72,7 +72,7 @@
 
 .group-count {
   font-size: 13px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .findings-list {
@@ -84,16 +84,16 @@
 /* Finding Cards */
 
 .finding-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
-  border-left: 3px solid #2a2d3a;
+  border-left: 3px solid var(--card-border);
   overflow: hidden;
   transition: all 0.2s;
 }
 
 .finding-card:hover {
-  border-color: #3a4050;
+  border-color: var(--card-hover-border);
   background: #1e2130;
 }
 
@@ -123,7 +123,7 @@
   margin: 0;
   font-size: 14px;
   font-weight: 600;
-  color: #e8eaed;
+  color: var(--app-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -140,7 +140,7 @@
 }
 
 .expand-icon {
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 10px;
   margin-left: 12px;
   flex-shrink: 0;
@@ -184,7 +184,7 @@
 
 .severity-badge.unknown {
   background: #2a2a2a;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 /* Finding Meta Row */
@@ -208,7 +208,7 @@
 
 .finding-scan-ref {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .finding-scan-ref a {
@@ -249,7 +249,7 @@
 
 .finding-card-details {
   padding: 0 16px 16px;
-  border-top: 1px solid #2a2d3a;
+  border-top: 1px solid var(--card-border);
   margin-top: 4px;
   padding-top: 16px;
 }
@@ -261,7 +261,7 @@
 .detail-block h5 {
   margin: 0 0 6px;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -269,7 +269,7 @@
 .detail-block p {
   margin: 0;
   font-size: 13px;
-  color: #ccc;
+  color: var(--app-text);
   line-height: 1.6;
   white-space: pre-wrap;
 }
@@ -294,7 +294,7 @@
 }
 
 .detail-label {
-  color: #888;
+  color: var(--app-text-secondary);
   font-weight: 600;
 }
 
@@ -308,7 +308,7 @@
 .cvss-value.low { color: #44ff44; }
 
 .cvss-vector {
-  color: #666;
+  color: var(--app-text-muted);
   font-size: 11px;
   font-family: monospace;
 }
@@ -332,7 +332,7 @@
 
 .triage-bucket {
   background: #14161e;
-  border: 1px solid #2a2d3a;
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 20px;
 }
@@ -352,7 +352,7 @@
 
 .bucket-count {
   background: #252830;
-  color: #aaa;
+  color: var(--nav-link-color);
   padding: 2px 10px;
   border-radius: 12px;
   font-size: 12px;
@@ -360,7 +360,7 @@
 }
 
 .bucket-empty {
-  color: #555;
+  color: var(--app-text-muted);
   font-size: 13px;
   font-style: italic;
   margin: 0;

--- a/frontend/src/pages/ReportsPage.css
+++ b/frontend/src/pages/ReportsPage.css
@@ -23,8 +23,8 @@
 
 .btn-secondary {
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #aaa;
+  border: 1px solid var(--input-border);
+  color: var(--nav-link-color);
   padding: 8px 12px;
   border-radius: 6px;
   cursor: pointer;
@@ -46,8 +46,8 @@
 }
 
 .report-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 20px;
   transition: all 0.2s;
@@ -56,8 +56,8 @@
 }
 
 .report-card:hover {
-  border-color: #3a4050;
-  background: #252c3a;
+  border-color: var(--card-hover-border);
+  background: var(--card-hover-bg);
 }
 
 .report-header {
@@ -112,7 +112,7 @@
   grid-template-columns: 1fr 1fr;
   gap: 12px;
   padding: 12px 0;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   margin-bottom: 12px;
 }
 
@@ -124,14 +124,14 @@
 
 .meta-item .label {
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .meta-item .value {
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
   font-weight: 600;
 }
 
@@ -143,7 +143,7 @@
 .report-findings-preview h4 {
   margin: 0 0 8px;
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -162,7 +162,7 @@
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: #aaa;
+  color: var(--nav-link-color);
 }
 
 .findings-list .severity {
@@ -204,7 +204,7 @@
 }
 
 .findings-list .more {
-  color: #666;
+  color: var(--app-text-muted);
   font-style: italic;
   padding: 4px 8px;
 }
@@ -225,7 +225,7 @@
   grid-column: 1 / -1;
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .empty-state p {
@@ -240,8 +240,8 @@
   align-items: center;
   justify-content: center;
   padding: 60px 24px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   text-align: center;
 }
@@ -255,13 +255,13 @@
   margin: 0 0 8px;
   font-size: 18px;
   font-weight: 600;
-  color: #ccc;
+  color: var(--app-text);
 }
 
 .empty-state-text {
   margin: 0 0 24px;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
   max-width: 400px;
   line-height: 1.5;
 }

--- a/frontend/src/pages/ScanComparisonPage.css
+++ b/frontend/src/pages/ScanComparisonPage.css
@@ -5,7 +5,7 @@
 }
 
 .comparison-page code {
-  background: #2a2d3a;
+  background: var(--card-border);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 13px;
@@ -38,7 +38,7 @@
   border-radius: 12px;
   padding: 20px;
   text-align: center;
-  border: 1px solid #2a2d3a;
+  border: 1px solid var(--card-border);
 }
 
 .card-value {
@@ -49,7 +49,7 @@
 
 .card-label {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -71,11 +71,11 @@
 }
 
 .card-unchanged {
-  border-color: #555;
+  border-color: var(--app-text-muted);
 }
 
 .card-unchanged .card-value {
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .card-changed {
@@ -91,7 +91,7 @@
   margin-bottom: 24px;
   background: #1e2230;
   border-radius: 12px;
-  border: 1px solid #2a2d3a;
+  border: 1px solid var(--card-border);
   overflow: hidden;
 }
 
@@ -116,17 +116,17 @@
 
 .toggle-icon {
   font-size: 12px;
-  color: #888;
+  color: var(--app-text-secondary);
   width: 16px;
 }
 
 .section-count {
   margin-left: auto;
-  background: #2a2d3a;
+  background: var(--card-border);
   padding: 2px 10px;
   border-radius: 10px;
   font-size: 13px;
-  color: #aaa;
+  color: var(--nav-link-color);
 }
 
 .section-content {
@@ -140,7 +140,7 @@
 .comparison-finding {
   padding: 14px 16px;
   border-radius: 8px;
-  border-left: 4px solid #2a2d3a;
+  border-left: 4px solid var(--card-border);
   background: #171a24;
 }
 
@@ -160,7 +160,7 @@
 }
 
 .finding-unchanged {
-  border-left-color: #555;
+  border-left-color: var(--app-text-muted);
 }
 
 .finding-header {
@@ -180,8 +180,8 @@
 .finding-category {
   display: inline-block;
   font-size: 11px;
-  color: #888;
-  background: #2a2d3a;
+  color: var(--app-text-secondary);
+  background: var(--card-border);
   padding: 2px 8px;
   border-radius: 4px;
   margin-bottom: 4px;
@@ -189,7 +189,7 @@
 
 .finding-description {
   font-size: 13px;
-  color: #999;
+  color: var(--app-text-secondary);
   margin: 6px 0 0;
   line-height: 1.4;
 }
@@ -236,6 +236,6 @@
 }
 
 .severity-change .arrow {
-  color: #888;
+  color: var(--app-text-secondary);
   font-size: 14px;
 }

--- a/frontend/src/pages/ScanDetailsPage.css
+++ b/frontend/src/pages/ScanDetailsPage.css
@@ -10,8 +10,8 @@
 
 .back-btn {
   background: transparent;
-  border: 1px solid #3a3d4a;
-  color: #aaa;
+  border: 1px solid var(--input-border);
+  color: var(--nav-link-color);
   padding: 6px 12px;
   border-radius: 6px;
   cursor: pointer;
@@ -41,9 +41,9 @@
 .btn {
   padding: 8px 16px;
   border-radius: 6px;
-  border: 1px solid #3a3d4a;
+  border: 1px solid var(--input-border);
   background: transparent;
-  color: #aaa;
+  color: var(--nav-link-color);
   cursor: pointer;
   font-size: 13px;
   transition: all 0.2s;
@@ -67,8 +67,8 @@
 
 .btn-secondary {
   background: transparent;
-  border-color: #3a3d4a;
-  color: #aaa;
+  border-color: var(--input-border);
+  color: var(--nav-link-color);
 }
 
 .scan-metadata {
@@ -76,8 +76,8 @@
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 16px;
   padding: 16px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   margin-bottom: 24px;
 }
@@ -90,14 +90,14 @@
 
 .metadata-item .label {
   font-size: 11px;
-  color: #666;
+  color: var(--app-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .metadata-item span {
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .badge {
@@ -129,14 +129,14 @@
   display: flex;
   gap: 0;
   margin-bottom: 24px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .tab {
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #666;
+  color: var(--app-text-muted);
   padding: 12px 16px;
   cursor: pointer;
   font-size: 13px;
@@ -145,7 +145,7 @@
 }
 
 .tab:hover {
-  color: #aaa;
+  color: var(--nav-link-color);
 }
 
 .tab.active {
@@ -168,8 +168,8 @@
 
 /* Findings Section */
 .findings-section {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -179,20 +179,20 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 1px solid #2a2d3a;
-  background: #111420;
+  border-bottom: 1px solid var(--card-border);
+  background: var(--app-bg);
 }
 
 .findings-count {
   font-size: 13px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .findings-controls select {
-  background: #0f1117;
-  border: 1px solid #3a3d4a;
+  background: var(--app-bg);
+  border: 1px solid var(--input-border);
   border-radius: 4px;
-  color: #e8eaed;
+  color: var(--app-text);
   padding: 6px 10px;
   font-size: 12px;
 }
@@ -203,31 +203,31 @@
 }
 
 .findings-table th {
-  background: #111420;
-  border-bottom: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
-  color: #888;
+  color: var(--app-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .findings-table td {
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding: 12px 16px;
   font-size: 13px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .findings-table tbody tr:hover {
-  background: #252c3a;
+  background: var(--card-hover-bg);
 }
 
 .empty-row {
   text-align: center;
-  color: #666;
+  color: var(--app-text-muted);
   padding: 40px !important;
 }
 
@@ -301,7 +301,7 @@
   top: 0;
   bottom: 0;
   width: 2px;
-  background: #2a2d3a;
+  background: var(--card-border);
 }
 
 .timeline-item {
@@ -317,7 +317,7 @@
   width: 16px;
   height: 16px;
   background: #2a3d50;
-  border: 2px solid #1a1d27;
+  border: 2px solid var(--card-bg);
   border-radius: 50%;
 }
 
@@ -347,8 +347,8 @@
 }
 
 .timeline-content {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   padding: 12px;
 }
@@ -356,13 +356,13 @@
 .timeline-title {
   font-size: 13px;
   font-weight: 600;
-  color: #e8eaed;
+  color: var(--app-text);
   margin-bottom: 4px;
 }
 
 .timeline-time {
   font-size: 12px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 /* Logs Section */
@@ -371,8 +371,8 @@
 }
 
 .logs-viewer {
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   padding: 16px;
   font-size: 11px;

--- a/frontend/src/pages/ScansPage.css
+++ b/frontend/src/pages/ScansPage.css
@@ -7,7 +7,7 @@
 .btn-new-scan {
   display: inline-block;
   background: #00d4ff;
-  color: #1a1d27;
+  color: var(--card-bg);
   font-weight: 600;
   font-size: 14px;
   padding: 10px 20px;
@@ -53,7 +53,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 24px;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .empty-state p {
@@ -74,18 +74,18 @@
 .scans-table th {
   text-align: left;
   padding: 12px 16px;
-  color: #888;
+  color: var(--app-text-secondary);
   font-weight: 600;
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .scans-table td {
   padding: 14px 16px;
-  border-bottom: 1px solid #2a2d3a;
-  color: #ccc;
+  border-bottom: 1px solid var(--card-border);
+  color: var(--app-text);
 }
 
 .scans-table tr:hover td {
@@ -103,7 +103,7 @@
 
 .scan-date {
   white-space: nowrap;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .status-badge {

--- a/frontend/src/pages/SettingsPage.css
+++ b/frontend/src/pages/SettingsPage.css
@@ -3,7 +3,7 @@
   display: flex;
   gap: 4px;
   margin-bottom: 24px;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
   padding-bottom: 0;
 }
 
@@ -11,7 +11,7 @@
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #888;
+  color: var(--app-text-secondary);
   font-size: 13px;
   padding: 10px 16px;
   cursor: pointer;
@@ -19,7 +19,7 @@
 }
 
 .settings-tab:hover {
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .settings-tab-active {
@@ -33,8 +33,8 @@
 }
 
 .settings-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 24px;
   margin-bottom: 20px;
@@ -51,7 +51,7 @@
   margin: 0 0 16px;
   font-size: 16px;
   font-weight: 600;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 .settings-card-header .settings-card-title {
@@ -81,13 +81,13 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #666;
+  color: var(--app-text-muted);
   font-weight: 600;
 }
 
 .settings-field span {
   font-size: 14px;
-  color: #e8eaed;
+  color: var(--app-text);
 }
 
 /* ─── Badges ──────────────────────────────────────────────────────── */
@@ -118,7 +118,7 @@
   font-size: 12px;
   font-weight: 600;
   background: #2a2a2a;
-  color: #888;
+  color: var(--app-text-secondary);
 }
 
 .settings-badge-red {
@@ -147,17 +147,17 @@
 
 .settings-form-field label {
   font-size: 12px;
-  color: #aaa;
+  color: var(--nav-link-color);
   font-weight: 500;
 }
 
 .settings-form-field input,
 .settings-select {
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   padding: 10px 12px;
-  color: #e8eaed;
+  color: var(--app-text);
   font-size: 13px;
   outline: none;
   transition: border-color 0.2s;
@@ -174,8 +174,8 @@
 }
 
 .settings-select option {
-  background: #111420;
-  color: #e8eaed;
+  background: var(--app-bg);
+  color: var(--app-text);
 }
 
 /* ─── Buttons ─────────────────────────────────────────────────────── */
@@ -213,7 +213,7 @@
 }
 
 .settings-btn-sm:hover {
-  background: #3a4050;
+  background: var(--card-hover-border);
 }
 
 .settings-btn-danger {
@@ -245,7 +245,7 @@
 }
 
 .settings-muted {
-  color: #888;
+  color: var(--app-text-secondary);
   font-size: 13px;
   margin: 0;
 }
@@ -266,16 +266,16 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #666;
+  color: var(--app-text-muted);
   font-weight: 600;
-  border-bottom: 1px solid #2a2d3a;
+  border-bottom: 1px solid var(--card-border);
 }
 
 .settings-table td {
   padding: 10px 12px;
   font-size: 13px;
-  color: #e8eaed;
-  border-bottom: 1px solid #1e2030;
+  color: var(--app-text);
+  border-bottom: 1px solid var(--card-bg);
 }
 
 .settings-table tr:last-child td {
@@ -313,8 +313,8 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 4px;
   padding: 8px 12px;
 }
@@ -323,7 +323,7 @@
   flex: 1;
   font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
   font-size: 12px;
-  color: #e8eaed;
+  color: var(--app-text);
   word-break: break-all;
 }
 
@@ -335,11 +335,11 @@
 }
 
 .settings-inline-input {
-  background: #111420;
-  border: 1px solid #2a2d3a;
+  background: var(--app-bg);
+  border: 1px solid var(--card-border);
   border-radius: 6px;
   padding: 10px 12px;
-  color: #e8eaed;
+  color: var(--app-text);
   font-size: 13px;
   outline: none;
   flex: 1;

--- a/frontend/src/pages/StubPage.css
+++ b/frontend/src/pages/StubPage.css
@@ -5,16 +5,16 @@
 }
 
 .feature-card {
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 8px;
   padding: 24px;
   transition: all 0.2s;
 }
 
 .feature-card:hover {
-  border-color: #3a4050;
-  background: #252c3a;
+  border-color: var(--card-hover-border);
+  background: var(--card-hover-bg);
 }
 
 .feature-card h2 {
@@ -25,7 +25,7 @@
 
 .feature-card p {
   margin: 0 0 16px;
-  color: #aaa;
+  color: var(--nav-link-color);
   font-size: 13px;
   line-height: 1.6;
 }
@@ -37,7 +37,7 @@
 }
 
 .feature-card li {
-  color: #aaa;
+  color: var(--nav-link-color);
   font-size: 13px;
   margin-bottom: 8px;
   position: relative;
@@ -55,7 +55,7 @@
 .coming-soon {
   text-align: center;
   padding: 60px 20px;
-  color: #666;
+  color: var(--app-text-muted);
 }
 
 .coming-soon-icon {
@@ -74,8 +74,8 @@
   align-items: center;
   justify-content: center;
   padding: 60px 24px;
-  background: #1a1d27;
-  border: 1px solid #2a2d3a;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   text-align: center;
 }
@@ -89,13 +89,13 @@
   margin: 0 0 8px;
   font-size: 18px;
   font-weight: 600;
-  color: #ccc;
+  color: var(--app-text);
 }
 
 .empty-state-text {
   margin: 0 0 24px;
   font-size: 14px;
-  color: #888;
+  color: var(--app-text-secondary);
   max-width: 400px;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- Migrated 20 CSS files from hardcoded dark-theme hex colors to CSS custom properties defined in `index.css`
- Enables the light/dark theme toggle to properly affect all pages and components across the dashboard
- Semantic colors (severity badges, accent blues, status indicators) are intentionally preserved as hardcoded values since they remain constant across themes

## Color mappings applied
| Hardcoded | CSS Variable |
|-----------|-------------|
| `#0f1117`, `#111420`, `#12141c` | `var(--app-bg)` |
| `#1a1d27` | `var(--card-bg)` |
| `#2a2d3a` | `var(--card-border)` |
| `#e8eaed`, `#ccc`, `#c8cacd` | `var(--app-text)` |
| `#888`, `#999` | `var(--app-text-secondary)` |
| `#666`, `#555`, `#444` | `var(--app-text-muted)` |
| `#252c3a` | `var(--card-hover-bg)` |
| `#3a4050` | `var(--card-hover-border)` |
| `#3a3d4a` | `var(--input-border)` |
| `#aaa` | `var(--nav-link-color)` |

## Files changed (20)
Components: FindingDetailModal, LoadingSkeleton, Navigation, Pagination, SearchModal, SecurityAdvisorChat
Pages: Assets, Campaigns, Compliance, Dashboard, Findings, Inventory, Posture, Remediation, Reports, ScanComparison, ScanDetails, Scans, Settings, Stub

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manually toggle dark/light mode and verify all pages render correctly
- [ ] Verify severity badges and accent colors remain unchanged

**Risk tier**: Tier 3 (CSS-only changes, no logic)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)