### PR TITLE
fix: add open redirect + cookie attack chain pattern

### DIFF
--- a/modules/agent/scan_agent.py
+++ b/modules/agent/scan_agent.py
@@ -2366,6 +2366,7 @@ def _run_reflector(client, text_output: str, system_prompt: str, tools: list,
 _ATTACK_CHAIN_PATTERNS = [
     ("open redirect", "xss"),
     ("open redirect", "session"),
+    ("open redirect", "cookie"),
     ("xss", "csrf"),
     ("xss", "admin"),
     ("information disclosure", "credentials"),


### PR DESCRIPTION
## Summary
- Adds `("open redirect", "cookie")` to `_ATTACK_CHAIN_PATTERNS` in `scan_agent.py`
- Fixes `test_chain_response_parsing` which fails because the heuristic filter rejects 2-finding combos without a matching pattern pair
- Risk Tier: Tier 2 (touches scan_agent.py)

## Test plan
- [x] `test_chain_response_parsing` passes with the new pattern
- [x] All other passing tests remain green (507 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)