### PR TITLE
fix: improve error observability in ES, worker, and scan retry

### DIFF
--- a/modules/api/routes/scans.py
+++ b/modules/api/routes/scans.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import time
 from datetime import datetime, timezone
@@ -15,6 +16,8 @@ from modules.infra.checkpoint import load_checkpoint, build_resume_context, dele
 from modules.infra.elasticsearch import search as es_search
 
 import redis as _redis
+
+logger = logging.getLogger(__name__)
 
 _REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379")
 _STUCK_TIMEOUT = int(os.environ.get("STUCK_SCAN_TIMEOUT_SECONDS", "600"))
@@ -190,8 +193,8 @@ def retry_scan(scan_id: str, user: User = Depends(get_current_user), db: Session
                     failed_steps.append(act)
             if failed_steps:
                 retry_context["failed_steps"] = failed_steps[:20]
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to parse activity log for scan %s during retry: %s", scan_id, e)
 
     # Create a new scan for the retry
     new_scan = Scan(

--- a/modules/infra/elasticsearch.py
+++ b/modules/infra/elasticsearch.py
@@ -53,7 +53,7 @@ def search(index: str, query: dict, size: int = 50, sort: list | None = None,
             body["aggs"] = aggs
         return es.search(index=index, body=body)
     except Exception as e:
-        log.warning("ES search failed (%s): %s", index, e)
+        log.warning("ES search failed on index=%s query=%s size=%d: %s", index, query, size, e)
         return {"hits": {"hits": [], "total": {"value": 0}}, "aggregations": {}}
 
 

--- a/modules/worker/__init__.py
+++ b/modules/worker/__init__.py
@@ -144,17 +144,25 @@ def _recover_orphaned_scans():
             )).fetchall()
 
         if not rows:
+            log.info("No orphaned scans found in 'running' status")
             return
 
         log.info("Found %d orphaned scan(s) in 'running' status", len(rows))
 
+        recovered_count = 0
+        failed_count = 0
         for row in rows:
             scan_id, target, scan_type, config = row[0], row[1], row[2], row[3]
             config = config or {}
 
             checkpoint = load_checkpoint(scan_id)
             if checkpoint:
-                log.info("Recovering scan %s from checkpoint (iteration %d)", scan_id, checkpoint.get("iteration", 0))
+                checkpoint_iteration = checkpoint.get("iteration", 0)
+                checkpoint_tools = checkpoint.get("tools_run", [])
+                log.info(
+                    "Recovering scan %s from checkpoint: iteration=%d, tools_run=%d, scan_type=%s, target=%s",
+                    scan_id, checkpoint_iteration, len(checkpoint_tools), scan_type, target,
+                )
                 resume_config = {**config, "resume_context": build_resume_context(checkpoint)}
                 _update_scan_status(scan_id, "queued")
                 queue.send(QUEUE_NAME, {
@@ -163,14 +171,24 @@ def _recover_orphaned_scans():
                     "scan_type": scan_type,
                     "config": resume_config,
                 })
+                recovered_count += 1
             else:
-                log.warning("No checkpoint for orphaned scan %s — marking failed", scan_id)
+                log.warning(
+                    "No checkpoint for orphaned scan %s (target=%s, scan_type=%s) — marking failed",
+                    scan_id, target, scan_type,
+                )
                 _update_scan_status(scan_id, "failed")
                 from modules.infra import get_storage
                 get_storage().put_json(f"scans/{scan_id}/error.json", {
                     "error": "Worker restarted with no checkpoint available. Scan could not be recovered.",
                     "scan_id": scan_id,
                 })
+                failed_count += 1
+
+        log.info(
+            "Orphaned scan recovery complete: %d recovered, %d failed out of %d total",
+            recovered_count, failed_count, len(rows),
+        )
     except Exception as e:
         log.error("Orphaned scan recovery failed: %s", e)
 


### PR DESCRIPTION
## Summary

- **ES search()**: Enhanced failure logging to include index name, query body, and size for better debugging of query failures
- **Worker `_recover_orphaned_scans()`**: Added structured logging with scan_id, checkpoint iteration, tools_run count, target, and scan_type; added recovery summary with recovered/failed counts
- **Scan retry route**: Replaced bare `except Exception: pass` with warning-level logging that captures scan_id and error details when parsing activity logs fails

**Risk tier: 1** — logging-only changes, no behavioral modifications

Closes #127

## Test plan

- [ ] Verify Python syntax passes for all three modified files (`python3 -c "import ast; ast.parse(open('file').read())"`)
- [ ] Confirm ES search fallback still returns empty results on failure (behavior unchanged)
- [ ] Confirm worker orphan recovery still recovers/fails scans correctly (behavior unchanged)
- [ ] Confirm scan retry route still creates retry scans even when activity log parsing fails (behavior unchanged)
- [ ] Check logs contain expected context (index name, scan_id, checkpoint state) during failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)