### PR TITLE
fix: replace alert() with toast, migrate inline styles

### DIFF
--- a/frontend/src/pages/AlertHistoryPage.css
+++ b/frontend/src/pages/AlertHistoryPage.css
@@ -1,0 +1,74 @@
+.alert-filter-bar {
+  margin-bottom: 20px;
+  display: flex;
+  gap: 12px;
+}
+
+.alert-filter-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--card-border);
+  background: transparent;
+  color: var(--app-text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.alert-filter-btn.active {
+  background: var(--card-hover-bg);
+  color: var(--app-accent);
+}
+
+.alert-filter-btn.active-critical {
+  background: var(--severity-critical-bg, #4a2a2a);
+  color: var(--severity-critical, #ff4444);
+}
+
+.alert-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alert-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.alert-card:hover {
+  border-color: var(--card-hover-border);
+  background: var(--card-hover-bg);
+}
+
+.alert-card-title {
+  margin: 0 0 4px;
+  color: var(--app-text);
+  font-size: 14px;
+}
+
+.alert-card-message {
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: 12px;
+}
+
+.alert-card-time {
+  margin: 4px 0 0;
+  color: var(--app-text-secondary);
+  font-size: 11px;
+}
+
+.alert-severity-badge {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--severity-critical-bg, #4a2a2a);
+  color: var(--severity-critical, #ff4444);
+}

--- a/frontend/src/pages/AlertHistoryPage.jsx
+++ b/frontend/src/pages/AlertHistoryPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import DetailModal from '../components/DetailModal'
 import './StubPage.css'
+import './AlertHistoryPage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
 
@@ -40,46 +41,22 @@ function AlertHistoryPage({ token }) {
         <p>View all security alerts and notifications</p>
       </div>
 
-      <div style={{ marginBottom: '20px', display: 'flex', gap: '12px' }}>
+      <div className="alert-filter-bar">
         <button
           onClick={() => setFilter('all')}
-          style={{
-            padding: '6px 12px',
-            border: '1px solid #3a3d4a',
-            background: filter === 'all' ? '#2a3d50' : 'transparent',
-            color: filter === 'all' ? '#4a9eff' : '#aaa',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '12px',
-          }}
+          className={`alert-filter-btn${filter === 'all' ? ' active' : ''}`}
         >
           All
         </button>
         <button
           onClick={() => setFilter('unread')}
-          style={{
-            padding: '6px 12px',
-            border: '1px solid #3a3d4a',
-            background: filter === 'unread' ? '#2a3d50' : 'transparent',
-            color: filter === 'unread' ? '#4a9eff' : '#aaa',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '12px',
-          }}
+          className={`alert-filter-btn${filter === 'unread' ? ' active' : ''}`}
         >
           Unread
         </button>
         <button
           onClick={() => setFilter('critical')}
-          style={{
-            padding: '6px 12px',
-            border: '1px solid #3a3d4a',
-            background: filter === 'critical' ? '#4a2a2a' : 'transparent',
-            color: filter === 'critical' ? '#ff4444' : '#aaa',
-            borderRadius: '6px',
-            cursor: 'pointer',
-            fontSize: '12px',
-          }}
+          className={`alert-filter-btn${filter === 'critical' ? ' active-critical' : ''}`}
         >
           Critical
         </button>
@@ -100,43 +77,25 @@ function AlertHistoryPage({ token }) {
           <Link to="/scans/new" className="empty-state-cta">Start a New Scan</Link>
         </div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <div className="alert-list">
           {alerts.map((alert) => (
             <div
               key={alert.id}
               onClick={() => setSelectedAlert(alert)}
-              style={{
-                background: '#1a1d27',
-                border: '1px solid #2a2d3a',
-                borderRadius: '8px',
-                padding: '16px',
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                cursor: 'pointer',
-              }}
+              className="alert-card"
             >
               <div>
-                <h3 style={{ margin: '0 0 4px', color: '#fff', fontSize: '14px' }}>
+                <h3 className="alert-card-title">
                   {alert.title || 'Alert'}
                 </h3>
-                <p style={{ margin: 0, color: '#888', fontSize: '12px' }}>
+                <p className="alert-card-message">
                   {alert.message || 'No description'}
                 </p>
-                <p style={{ margin: '4px 0 0', color: '#666', fontSize: '11px' }}>
+                <p className="alert-card-time">
                   {new Date(alert.created_at).toLocaleString()}
                 </p>
               </div>
-              <span
-                style={{
-                  padding: '4px 10px',
-                  borderRadius: '4px',
-                  fontSize: '11px',
-                  fontWeight: 600,
-                  background: '#4a2a2a',
-                  color: '#ff4444',
-                }}
-              >
+              <span className="alert-severity-badge">
                 {alert.severity || 'info'}
               </span>
             </div>

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import FindingDetailModal from '../components/FindingDetailModal'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { Pagination } from '../components/Pagination'
+import { useToast } from '../components/ToastContext'
 import './FindingsPage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
@@ -31,6 +32,7 @@ function StatusBadge({ status }) {
 }
 
 function StatusDropdown({ finding, token, onStatusChange }) {
+  const { showToast } = useToast()
   const [changing, setChanging] = useState(false)
   const [showReason, setShowReason] = useState(false)
   const [pendingStatus, setPendingStatus] = useState('')
@@ -69,7 +71,7 @@ function StatusDropdown({ finding, token, onStatusChange }) {
       }
       onStatusChange(finding.id, status)
     } catch (err) {
-      alert(err.message)
+      showToast(err.message, 'error')
     } finally {
       setChanging(false)
       setReason('')

--- a/frontend/src/pages/QueuePage.css
+++ b/frontend/src/pages/QueuePage.css
@@ -1,0 +1,45 @@
+.queue-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.queue-table thead tr {
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--card-border);
+}
+
+.queue-table th {
+  padding: 12px 16px;
+  text-align: left;
+  color: var(--app-text-muted);
+}
+
+.queue-table tbody tr {
+  border-bottom: 1px solid var(--card-border);
+}
+
+.queue-table td {
+  padding: 12px 16px;
+  color: var(--app-text);
+}
+
+.queue-table td.muted {
+  color: var(--app-text-muted);
+}
+
+.queue-status-badge {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.queue-status-badge.running {
+  background: var(--card-hover-bg, #2a3a4a);
+  color: var(--app-accent, #4a9eff);
+}
+
+.queue-status-badge.queued {
+  background: var(--severity-medium-bg, #3a3a2a);
+  color: var(--severity-medium, #ffaa44);
+}

--- a/frontend/src/pages/QueuePage.jsx
+++ b/frontend/src/pages/QueuePage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import './StubPage.css'
+import './QueuePage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
 
@@ -59,33 +60,26 @@ function QueuePage({ token }) {
           <Link to="/scans/new" className="empty-state-cta">Start a New Scan</Link>
         </div>
       ) : (
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className="queue-table">
           <thead>
-            <tr style={{ background: '#111420', borderBottom: '1px solid #2a2d3a' }}>
-              <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>Target</th>
-              <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>Status</th>
-              <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>Position</th>
-              <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>ETA</th>
+            <tr>
+              <th>Target</th>
+              <th>Status</th>
+              <th>Position</th>
+              <th>ETA</th>
             </tr>
           </thead>
           <tbody>
             {queue.map((scan, idx) => (
-              <tr key={scan.id} style={{ borderBottom: '1px solid #2a2d3a' }}>
-                <td style={{ padding: '12px 16px', color: '#e8eaed' }}>{scan.target_url || 'N/A'}</td>
-                <td style={{ padding: '12px 16px' }}>
-                  <span style={{
-                    padding: '4px 10px',
-                    borderRadius: '4px',
-                    fontSize: '12px',
-                    fontWeight: 600,
-                    background: scan.status === 'running' ? '#2a3a4a' : '#3a3a2a',
-                    color: scan.status === 'running' ? '#4a9eff' : '#ffaa44'
-                  }}>
+              <tr key={scan.id}>
+                <td>{scan.target_url || 'N/A'}</td>
+                <td>
+                  <span className={`queue-status-badge ${scan.status}`}>
                     {scan.status}
                   </span>
                 </td>
-                <td style={{ padding: '12px 16px', color: '#888' }}>{idx + 1}</td>
-                <td style={{ padding: '12px 16px', color: '#888' }}>~5 min</td>
+                <td className="muted">{idx + 1}</td>
+                <td className="muted">~5 min</td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- **FindingsPage**: Replaced `alert()` call in `StatusDropdown` error handler with `showToast()` from `useToast()` for consistent toast notifications
- **AlertHistoryPage**: Migrated all inline styles to `AlertHistoryPage.css` using CSS variables (`var(--card-bg)`, `var(--app-text)`, etc.) for proper dark mode support
- **QueuePage**: Migrated all inline styles to `QueuePage.css` using CSS variables for proper dark mode support

**Risk tier**: Tier 1 (UI-only, no backend changes)

Closes #124

## Test plan
- [ ] Verify FindingsPage status change errors show as toast notifications (not browser alerts)
- [ ] Verify AlertHistoryPage renders correctly with filter buttons and alert cards styled via CSS
- [ ] Verify QueuePage table renders correctly with styles from QueuePage.css
- [ ] Verify dark mode appearance is consistent across all three pages
- [ ] Run `npm run build` to confirm frontend compiles
- [ ] Run `npm run lint` to confirm no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)