### PR TITLE
feat: add confirmation dialogs for destructive actions

### DIFF
--- a/frontend/src/components/ConfirmDialog.css
+++ b/frontend/src/components/ConfirmDialog.css
@@ -1,0 +1,114 @@
+.confirm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  backdrop-filter: blur(4px);
+  animation: confirmFadeIn 0.15s ease-out;
+}
+
+.confirm-dialog {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 420px;
+  padding: 24px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: confirmSlideIn 0.15s ease-out;
+}
+
+.confirm-dialog-title {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.confirm-dialog-description {
+  margin: 0 0 24px;
+  font-size: 0.88rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+.confirm-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-btn {
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: opacity 0.15s;
+}
+
+.confirm-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.confirm-btn-cancel {
+  background: transparent;
+  border-color: #334155;
+  color: #94a3b8;
+}
+
+.confirm-btn-cancel:hover:not(:disabled) {
+  background: #1a1d27;
+  color: #e2e8f0;
+}
+
+.confirm-btn-danger {
+  background: #5a2a2a;
+  color: #ff6b6b;
+  border-color: #5a2a2a;
+}
+
+.confirm-btn-danger:hover:not(:disabled) {
+  background: #6a3333;
+}
+
+.confirm-btn-warning {
+  background: #4a3a1a;
+  color: #ffcc44;
+  border-color: #4a3a1a;
+}
+
+.confirm-btn-warning:hover:not(:disabled) {
+  background: #5a4422;
+}
+
+.confirm-btn-primary {
+  background: #2a3d50;
+  color: #4a9eff;
+  border-color: #3a5070;
+}
+
+.confirm-btn-primary:hover:not(:disabled) {
+  background: #33486a;
+}
+
+@keyframes confirmFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes confirmSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+import './ConfirmDialog.css'
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  confirmVariant = 'danger',
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}) {
+  useEffect(() => {
+    if (!open) return
+    function handleEsc(e) {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handleEsc)
+    return () => document.removeEventListener('keydown', handleEsc)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div className="confirm-dialog-overlay" onClick={onCancel}>
+      <div className="confirm-dialog" onClick={e => e.stopPropagation()}>
+        <h3 className="confirm-dialog-title">{title}</h3>
+        <p className="confirm-dialog-description">{description}</p>
+        <div className="confirm-dialog-footer">
+          <button
+            className="confirm-btn confirm-btn-cancel"
+            onClick={onCancel}
+            disabled={isLoading}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            className={`confirm-btn confirm-btn-${confirmVariant}`}
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? 'Processing...' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import ConfirmDialog from '../components/ConfirmDialog'
 import FindingDetailModal from '../components/FindingDetailModal'
 import { LoadingSkeleton } from '../components/LoadingSkeleton'
 import { Pagination } from '../components/Pagination'
@@ -37,20 +38,36 @@ function StatusDropdown({ finding, token, onStatusChange }) {
   const [showReason, setShowReason] = useState(false)
   const [pendingStatus, setPendingStatus] = useState('')
   const [reason, setReason] = useState('')
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const CONFIRM_DESCRIPTIONS = {
+    false_positive: 'This will mark the finding as a false positive. The finding will be excluded from future reports.',
+    accepted_risk: 'This will mark the finding as an accepted risk. Ensure this has been reviewed and approved.',
+  }
 
   async function handleChange(e) {
     const newStatus = e.target.value
     const currentStatus = finding.finding_status || 'new'
     if (newStatus === currentStatus) return
 
-    // For false_positive and accepted_risk, ask for a reason
+    // For false_positive and accepted_risk, confirm first
     if (newStatus === 'false_positive' || newStatus === 'accepted_risk') {
       setPendingStatus(newStatus)
-      setShowReason(true)
+      setShowConfirm(true)
       return
     }
 
     await submitStatusChange(newStatus, '')
+  }
+
+  function handleConfirmAccept() {
+    setShowConfirm(false)
+    setShowReason(true)
+  }
+
+  function handleConfirmCancel() {
+    setShowConfirm(false)
+    setPendingStatus('')
   }
 
   async function submitStatusChange(status, changeReason) {
@@ -123,6 +140,15 @@ function StatusDropdown({ finding, token, onStatusChange }) {
           </form>
         </div>
       )}
+      <ConfirmDialog
+        open={showConfirm}
+        title={`Mark as ${STATUS_MAP[pendingStatus]?.label || ''}?`}
+        description={CONFIRM_DESCRIPTIONS[pendingStatus] || ''}
+        confirmLabel="Continue"
+        confirmVariant="warning"
+        onConfirm={handleConfirmAccept}
+        onCancel={handleConfirmCancel}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/RemediationPage.jsx
+++ b/frontend/src/pages/RemediationPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/ToastContext'
 import './RemediationPage.css'
 
@@ -20,6 +21,7 @@ function RemediationPage({ token }) {
   const [activeTab, setActiveTab] = useState('severity')
   const [verifyingIds, setVerifyingIds] = useState(new Set())
   const [expandedIds, setExpandedIds] = useState(new Set())
+  const [confirmVerifyScanId, setConfirmVerifyScanId] = useState(null)
 
   useEffect(() => {
     fetchScansAndFindings()
@@ -196,7 +198,7 @@ function RemediationPage({ token }) {
             <div className="finding-card-actions">
               <button
                 className="btn btn-primary btn-sm"
-                onClick={() => triggerVerification(finding.scanId)}
+                onClick={() => setConfirmVerifyScanId(finding.scanId)}
                 disabled={verifyingIds.has(finding.scanId)}
               >
                 {verifyingIds.has(finding.scanId) ? 'Verifying...' : 'Trigger Verification Scan'}
@@ -314,6 +316,21 @@ function RemediationPage({ token }) {
           {renderTriageBucket('Backlog', triageBuckets.backlog, 'bucket-backlog')}
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmVerifyScanId !== null}
+        title="Trigger Verification Scan?"
+        description="This will queue a verification scan for this finding. Verification scans are resource-intensive and may take several minutes."
+        confirmLabel="Trigger Scan"
+        confirmVariant="warning"
+        onConfirm={() => {
+          const scanId = confirmVerifyScanId
+          setConfirmVerifyScanId(null)
+          triggerVerification(scanId)
+        }}
+        onCancel={() => setConfirmVerifyScanId(null)}
+        isLoading={confirmVerifyScanId !== null && verifyingIds.has(confirmVerifyScanId)}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/SchedulesPage.jsx
+++ b/frontend/src/pages/SchedulesPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import ConfirmDialog from '../components/ConfirmDialog'
 import DetailModal from '../components/DetailModal'
 import './StubPage.css'
 
@@ -304,30 +305,13 @@ function SchedulesPage({ token }) {
                       >
                         Edit
                       </button>
-                      {confirmingDelete === sched.id ? (
-                        <>
-                          <button
-                            onClick={() => handleDelete(sched.id)}
-                            style={{ ...actionBtnStyle, borderColor: '#5a2a2a', color: '#ff6b6b' }}
-                          >
-                            Confirm
-                          </button>
-                          <button
-                            onClick={() => setConfirmingDelete(null)}
-                            style={actionBtnStyle}
-                          >
-                            Cancel
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          onClick={() => setConfirmingDelete(sched.id)}
-                          style={{ ...actionBtnStyle, borderColor: '#5a2a2a', color: '#ff6b6b' }}
-                          title="Delete schedule"
-                        >
-                          Delete
-                        </button>
-                      )}
+                      <button
+                        onClick={() => setConfirmingDelete(sched.id)}
+                        style={{ ...actionBtnStyle, borderColor: '#5a2a2a', color: '#ff6b6b' }}
+                        title="Delete schedule"
+                      >
+                        Delete
+                      </button>
                     </div>
                   </td>
                 </tr>
@@ -344,6 +328,16 @@ function SchedulesPage({ token }) {
           onClose={() => setSelectedSchedule(null)}
         />
       )}
+
+      <ConfirmDialog
+        open={confirmingDelete !== null}
+        title="Delete Schedule?"
+        description="This will permanently delete the scheduled scan. This action cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="danger"
+        onConfirm={() => handleDelete(confirmingDelete)}
+        onCancel={() => setConfirmingDelete(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Created reusable `ConfirmDialog` component with overlay, Escape key handling, click-outside-to-close, and variant support (danger/warning/primary)
- Added confirmation before marking findings as false positive or accepted risk in FindingsPage
- Added confirmation before triggering verification scans in RemediationPage
- Replaced inline confirm/cancel buttons with ConfirmDialog in SchedulesPage for schedule deletion

Closes #129

## Risk
Tier 1 — Frontend-only UI enhancement, no backend changes, no API contract changes.

## Test plan
- [ ] FindingsPage: select `false_positive` from dropdown → dialog appears → Cancel → no change; Confirm → reason popover appears
- [ ] FindingsPage: select `accepted_risk` from dropdown → same flow
- [ ] RemediationPage: click "Trigger Verification Scan" → dialog appears → Cancel → no API call; Confirm → scan queued
- [ ] SchedulesPage: click Delete → dialog appears → Cancel → schedule remains; Confirm → schedule deleted
- [ ] All dialogs: Escape key closes without action
- [ ] All dialogs: clicking overlay closes without action

🤖 Generated with [Claude Code](https://claude.com/claude-code)