### PR TITLE
feat: add breadcrumb navigation to all pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import ScansPage from './pages/ScansPage'
 import ScanComparisonPage from './pages/ScanComparisonPage'
 import ScanWizard from './components/ScanWizard'
 import Navigation from './components/Navigation'
+import Breadcrumbs from './components/Breadcrumbs'
 import ErrorBoundary from './components/ErrorBoundary'
 import './App.css'
 
@@ -114,6 +115,7 @@ function AppLayout({ token, onLogout }) {
     <div className="app-layout">
       <Navigation onLogout={onLogout} />
       <main className="app-main">
+        <Breadcrumbs />
         <ErrorBoundary>
           <Routes>
             <Route path="/" element={<Dashboard token={token} />} />

--- a/frontend/src/components/Breadcrumbs.css
+++ b/frontend/src/components/Breadcrumbs.css
@@ -1,0 +1,50 @@
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  padding: 0 4px;
+}
+
+.breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.breadcrumb-separator {
+  color: var(--app-text-muted, #555);
+  margin: 0 4px;
+  user-select: none;
+}
+
+.breadcrumb-link {
+  color: var(--app-text-secondary, #888);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.breadcrumb-link:hover {
+  color: var(--app-text, #e8eaed);
+}
+
+.breadcrumb-current {
+  color: var(--app-text, #e8eaed);
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .breadcrumbs {
+    font-size: 12px;
+  }
+
+  .breadcrumb-link,
+  .breadcrumb-current {
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -1,0 +1,63 @@
+import { Link, useLocation } from 'react-router-dom'
+import './Breadcrumbs.css'
+
+const ROUTE_LABELS = {
+  scans: 'Scans',
+  new: 'New Scan',
+  findings: 'Findings',
+  reports: 'Reports',
+  compliance: 'Compliance',
+  remediation: 'Remediation',
+  schedules: 'Schedules',
+  webhooks: 'Webhooks',
+  campaigns: 'Campaigns',
+  queue: 'Queue',
+  alerts: 'Alerts',
+  assets: 'Assets',
+  inventory: 'Inventory',
+  posture: 'Posture',
+  'audit-logs': 'Audit Logs',
+  settings: 'Settings',
+  advisor: 'Advisor',
+  compare: 'Comparison',
+}
+
+function resolveLabel(segment) {
+  if (ROUTE_LABELS[segment]) return ROUTE_LABELS[segment]
+  // Dynamic segment (scan ID, baseline ID) — truncate to 8 chars
+  if (segment.length > 8) return segment.substring(0, 8)
+  return segment
+}
+
+export default function Breadcrumbs() {
+  const { pathname } = useLocation()
+
+  if (pathname === '/') return null
+
+  const segments = pathname.split('/').filter(Boolean)
+  const crumbs = [{ label: 'Dashboard', path: '/' }]
+
+  let currentPath = ''
+  for (let i = 0; i < segments.length; i++) {
+    currentPath += `/${segments[i]}`
+    crumbs.push({
+      label: resolveLabel(segments[i], i, segments),
+      path: currentPath,
+    })
+  }
+
+  return (
+    <nav className="breadcrumbs" aria-label="Breadcrumb">
+      {crumbs.map((crumb, idx) => (
+        <span key={crumb.path} className="breadcrumb-item">
+          {idx > 0 && <span className="breadcrumb-separator" aria-hidden="true">/</span>}
+          {idx < crumbs.length - 1 ? (
+            <Link className="breadcrumb-link" to={crumb.path}>{crumb.label}</Link>
+          ) : (
+            <span className="breadcrumb-current" aria-current="page">{crumb.label}</span>
+          )}
+        </span>
+      ))}
+    </nav>
+  )
+}

--- a/frontend/src/pages/ScanDetailsPage.css
+++ b/frontend/src/pages/ScanDetailsPage.css
@@ -8,22 +8,6 @@
   gap: 16px;
 }
 
-.back-btn {
-  background: transparent;
-  border: 1px solid var(--input-border);
-  color: var(--nav-link-color);
-  padding: 6px 12px;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 13px;
-  transition: all 0.2s;
-  margin-top: 2px;
-}
-
-.back-btn:hover {
-  border-color: #4a5a6a;
-  color: #fff;
-}
 
 .page-header {
   display: flex;

--- a/frontend/src/pages/ScanDetailsPage.jsx
+++ b/frontend/src/pages/ScanDetailsPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useToast } from '../components/ToastContext'
 import { useScanUpdates } from '../hooks/useWebSocket'
 import FindingDetailModal from '../components/FindingDetailModal'
@@ -9,7 +9,6 @@ const API_BASE = import.meta.env.VITE_API_URL || ''
 
 function ScanDetailsPage({ token }) {
   const { scanId } = useParams()
-  const navigate = useNavigate()
   const { showToast } = useToast()
   const [scan, setScan] = useState(null)
   const [findings, setFindings] = useState([])
@@ -116,7 +115,6 @@ function ScanDetailsPage({ token }) {
     <div className="page-container scan-details">
       <div className="page-header">
         <div className="header-title">
-          <button className="back-btn" onClick={() => navigate('/reports')}>← Back</button>
           <div>
             <h1>{scan.target_url || 'Scan Details'}</h1>
             <p>Target: {scan.target_url || 'Unknown'}</p>


### PR DESCRIPTION
## Summary
- Created reusable `Breadcrumbs` component that auto-generates navigation from the current route path
- Integrated into `AppLayout` so breadcrumbs appear on all authenticated pages (hidden on Dashboard)
- Removed the `← Back` button from ScanDetailsPage — breadcrumbs provide equivalent navigation
- Route labels map all 17+ routes; dynamic segments (scan IDs) are truncated to 8 chars
- Responsive: truncates long labels on mobile with ellipsis

Closes #123

## Risk
Tier 1 — Frontend-only UI enhancement, no backend changes.

## Test plan
- [ ] Dashboard (`/`): breadcrumbs should NOT appear
- [ ] Top-level pages (`/scans`, `/findings`, etc.): shows `Dashboard / Scans`
- [ ] Scan details (`/scans/<id>`): shows `Dashboard / Scans / <truncated-id>`
- [ ] Scan comparison (`/scans/<id>/compare/<id>`): shows `Dashboard / Scans / <id> / Comparison`
- [ ] New scan (`/scans/new`): shows `Dashboard / Scans / New Scan`
- [ ] All breadcrumb links except the last are clickable and navigate correctly
- [ ] ScanDetailsPage back button is gone, breadcrumbs provide navigation
- [ ] Mobile: breadcrumbs don't overflow, labels truncate

🤖 Generated with [Claude Code](https://claude.com/claude-code)