### PR TITLE
feat: add accessibility ARIA labels and focus trapping

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,7 +66,7 @@ function LoginForm({ onLogin }) {
     <div className="login-container">
       <div className="login-card">
         <div className="login-header">
-          <span className="login-icon">🛡️</span>
+          <span className="login-icon" role="img" aria-label="Security shield">🛡️</span>
           <h1>SSSAI Security Advisor</h1>
           <p>Sign in to access your AI security dashboard</p>
         </div>
@@ -87,7 +87,7 @@ function LoginForm({ onLogin }) {
             required
             className="login-input"
           />
-          {error && <div className="login-error">{error}</div>}
+          {error && <div className="login-error" role="alert" aria-live="assertive">{error}</div>}
           <button type="submit" className="login-btn" disabled={loading}>
             {loading ? 'Signing in…' : 'Sign In'}
           </button>
@@ -114,7 +114,7 @@ function AppLayout({ token, onLogout }) {
   return (
     <div className="app-layout">
       <Navigation onLogout={onLogout} />
-      <main className="app-main">
+      <main className="app-main" aria-label="Main content">
         <Breadcrumbs />
         <ErrorBoundary>
           <Routes>

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
 import './ConfirmDialog.css'
 
 export default function ConfirmDialog({
@@ -21,12 +22,15 @@ export default function ConfirmDialog({
     return () => document.removeEventListener('keydown', handleEsc)
   }, [open, onCancel])
 
+  const dialogRef = useRef(null)
+  useFocusTrap(dialogRef, open)
+
   if (!open) return null
 
   return (
-    <div className="confirm-dialog-overlay" onClick={onCancel}>
-      <div className="confirm-dialog" onClick={e => e.stopPropagation()}>
-        <h3 className="confirm-dialog-title">{title}</h3>
+    <div className="confirm-dialog-overlay" onClick={onCancel} role="dialog" aria-modal="true">
+      <div className="confirm-dialog" onClick={e => e.stopPropagation()} ref={dialogRef} aria-labelledby="confirm-dialog-title">
+        <h3 className="confirm-dialog-title" id="confirm-dialog-title">{title}</h3>
         <p className="confirm-dialog-description">{description}</p>
         <div className="confirm-dialog-footer">
           <button

--- a/frontend/src/components/DetailModal.jsx
+++ b/frontend/src/components/DetailModal.jsx
@@ -1,7 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
 import './DetailModal.css'
 
 export default function DetailModal({ title, data, onClose }) {
+  const modalRef = useRef(null)
+  useFocusTrap(modalRef, !!data)
+
   useEffect(() => {
     function handleEsc(e) { if (e.key === 'Escape') onClose() }
     document.addEventListener('keydown', handleEsc)
@@ -34,11 +38,11 @@ export default function DetailModal({ title, data, onClose }) {
   const entries = typeof data === 'object' && !Array.isArray(data) ? Object.entries(data) : []
 
   return (
-    <div className="detail-overlay" onClick={onClose}>
-      <div className="detail-modal" onClick={e => e.stopPropagation()}>
+    <div className="detail-overlay" onClick={onClose} role="dialog" aria-modal="true">
+      <div className="detail-modal" onClick={e => e.stopPropagation()} ref={modalRef} aria-labelledby="detail-modal-title">
         <div className="detail-header">
-          <h2>{title || 'Details'}</h2>
-          <button className="detail-close" onClick={onClose}>&times;</button>
+          <h2 id="detail-modal-title">{title || 'Details'}</h2>
+          <button className="detail-close" onClick={onClose} aria-label="Close dialog">&times;</button>
         </div>
         <div className="detail-body">
           {entries.length > 0 ? (

--- a/frontend/src/components/FindingDetailModal.jsx
+++ b/frontend/src/components/FindingDetailModal.jsx
@@ -1,7 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
 import './FindingDetailModal.css'
 
 export default function FindingDetailModal({ finding, onClose }) {
+  const modalRef = useRef(null)
+  useFocusTrap(modalRef, !!finding)
+
   useEffect(() => {
     function handleEsc(e) { if (e.key === 'Escape') onClose() }
     document.addEventListener('keydown', handleEsc)
@@ -20,8 +24,8 @@ export default function FindingDetailModal({ finding, onClose }) {
   const color = severityColors[finding.severity] || '#888'
 
   return (
-    <div className="fdm-overlay" onClick={onClose}>
-      <div className="fdm-modal" onClick={e => e.stopPropagation()}>
+    <div className="fdm-overlay" onClick={onClose} role="dialog" aria-modal="true">
+      <div className="fdm-modal" onClick={e => e.stopPropagation()} ref={modalRef} aria-label={finding.title || 'Finding Details'}>
         {/* Header with severity stripe */}
         <div className="fdm-header" style={{ borderTopColor: color }}>
           <div className="fdm-header-top">
@@ -31,7 +35,7 @@ export default function FindingDetailModal({ finding, onClose }) {
             {finding.cvss_score && (
               <span className="fdm-cvss">CVSS {finding.cvss_score}</span>
             )}
-            <button className="fdm-close" onClick={onClose}>&times;</button>
+            <button className="fdm-close" onClick={onClose} aria-label="Close dialog">&times;</button>
           </div>
           <h2 className="fdm-title">{finding.title || 'Finding Details'}</h2>
           <div className="fdm-meta-row">
@@ -72,7 +76,7 @@ export default function FindingDetailModal({ finding, onClose }) {
           {finding.remediation && (
             <section className="fdm-section fdm-remediation">
               <h3 className="fdm-section-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
                 </svg>
                 How to Fix
@@ -166,7 +170,7 @@ export default function FindingDetailModal({ finding, onClose }) {
 
         {/* Footer */}
         <div className="fdm-footer">
-          <button className="fdm-btn fdm-btn-close" onClick={onClose}>Close</button>
+          <button className="fdm-btn fdm-btn-close" onClick={onClose} aria-label="Close dialog">Close</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -27,24 +27,25 @@ function Navigation({ onLogout }) {
   ]
 
   return (
-    <nav className="sidebar-nav">
+    <nav className="sidebar-nav" aria-label="Main navigation">
       <div className="nav-header">
-        <div className="nav-brand">🛡️ SSSAI</div>
+        <div className="nav-brand"><span aria-hidden="true">🛡️</span> SSSAI</div>
         <div className="nav-subtitle">Security Scanner</div>
       </div>
 
       <div className="nav-new-scan">
-        <Link to="/scans/new" className="new-scan-btn">+ New Scan</Link>
+        <Link to="/scans/new" className="new-scan-btn" aria-label="Create new scan">+ New Scan</Link>
       </div>
 
-      <ul className="nav-menu">
+      <ul className="nav-menu" role="list">
         {navItems.map((item) => (
           <li key={item.label}>
             <Link
               to={item.path}
               className={`nav-link ${location.pathname === item.path ? 'active' : ''}`}
+              {...(location.pathname === item.path ? { 'aria-current': 'page' } : {})}
             >
-              <span className="nav-icon">{item.icon}</span>
+              <span className="nav-icon" aria-hidden="true">{item.icon}</span>
               <span className="nav-label">{item.label}</span>
             </Link>
           </li>
@@ -52,10 +53,10 @@ function Navigation({ onLogout }) {
       </ul>
 
       <div className="nav-footer">
-        <button onClick={toggleTheme} className="theme-toggle-btn" title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
+        <button onClick={toggleTheme} className="theme-toggle-btn" title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`} aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}>
           {theme === 'dark' ? '\u2600\uFE0F Light Mode' : '\uD83C\uDF19 Dark Mode'}
         </button>
-        <button onClick={onLogout} className="logout-btn">
+        <button onClick={onLogout} className="logout-btn" aria-label="Sign out">
           Sign Out
         </button>
       </div>

--- a/frontend/src/components/SearchModal.jsx
+++ b/frontend/src/components/SearchModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useFocusTrap } from '../hooks/useFocusTrap'
 import './SearchModal.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
@@ -11,6 +12,8 @@ export function SearchModal({ open, onClose, token }) {
   const [activeIndex, setActiveIndex] = useState(0)
   const inputRef = useRef(null)
   const debounceRef = useRef(null)
+  const searchModalRef = useRef(null)
+  useFocusTrap(searchModalRef, open)
   const navigate = useNavigate()
 
   // Focus input when modal opens
@@ -111,10 +114,10 @@ export function SearchModal({ open, onClose, token }) {
   let globalIdx = 0
 
   return (
-    <div className="search-modal-overlay" onClick={handleOverlayClick}>
-      <div className="search-modal" onKeyDown={handleKeyDown}>
+    <div className="search-modal-overlay" onClick={handleOverlayClick} role="dialog" aria-modal="true">
+      <div className="search-modal" onKeyDown={handleKeyDown} ref={searchModalRef} aria-label="Global search">
         <div className="search-modal-input-wrapper">
-          <svg className="search-modal-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg className="search-modal-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <circle cx="11" cy="11" r="8" />
             <line x1="21" y1="21" x2="16.65" y2="16.65" />
           </svg>
@@ -125,11 +128,12 @@ export function SearchModal({ open, onClose, token }) {
             placeholder="Search findings, scans, activity..."
             value={query}
             onChange={handleInputChange}
+            aria-label="Search findings, scans, and activity"
           />
           <span className="search-modal-kbd">ESC</span>
         </div>
 
-        <div className="search-modal-body">
+        <div className="search-modal-body" aria-live="polite">
           {loading && (
             <div className="search-modal-loading">Searching...</div>
           )}
@@ -155,7 +159,7 @@ export function SearchModal({ open, onClose, token }) {
           {!loading && findings.length > 0 && (
             <div className="search-modal-section">
               <div className="search-modal-section-title">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                 </svg>
                 Findings
@@ -170,7 +174,7 @@ export function SearchModal({ open, onClose, token }) {
                     onClick={() => navigateToResult({ type: 'finding', data: f })}
                   >
                     <div className="search-modal-result-icon finding">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                       </svg>
                     </div>
@@ -194,7 +198,7 @@ export function SearchModal({ open, onClose, token }) {
           {!loading && activities.length > 0 && (
             <div className="search-modal-section">
               <div className="search-modal-section-title">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                 </svg>
                 Scans / Activity
@@ -209,7 +213,7 @@ export function SearchModal({ open, onClose, token }) {
                     onClick={() => navigateToResult({ type: 'scan', data: a })}
                   >
                     <div className="search-modal-result-icon scan">
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                         <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                       </svg>
                     </div>

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -14,13 +14,14 @@ function Toast() {
   if (toasts.length === 0) return null
 
   return (
-    <div className="toast-container">
+    <div className="toast-container" aria-live="polite" aria-relevant="additions removals">
       {toasts.map(toast => (
         <div
           key={toast.id}
           className={`toast toast-${toast.type}${toast.removing ? ' removing' : ''}`}
+          role={toast.type === 'error' ? 'alert' : 'status'}
         >
-          <span className="toast-icon">{ICONS[toast.type] || ICONS.info}</span>
+          <span className="toast-icon" aria-hidden="true">{ICONS[toast.type] || ICONS.info}</span>
           <span className="toast-message">{toast.message}</span>
           <button
             className="toast-dismiss"

--- a/frontend/src/hooks/useFocusTrap.js
+++ b/frontend/src/hooks/useFocusTrap.js
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react'
+
+const FOCUSABLE_SELECTOR = 'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+
+export function useFocusTrap(containerRef, enabled) {
+  const previousFocusRef = useRef(null)
+
+  useEffect(() => {
+    if (!enabled || !containerRef.current) return
+
+    previousFocusRef.current = document.activeElement
+
+    const container = containerRef.current
+    const focusableElements = container.querySelectorAll(FOCUSABLE_SELECTOR)
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus()
+    }
+
+    function handleKeyDown(e) {
+      if (e.key !== 'Tab') return
+      const focusable = container.querySelectorAll(FOCUSABLE_SELECTOR)
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown)
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown)
+      if (previousFocusRef.current && previousFocusRef.current.focus) {
+        previousFocusRef.current.focus()
+      }
+    }
+  }, [containerRef, enabled])
+}


### PR DESCRIPTION
## Summary
- Created `useFocusTrap` hook for keyboard focus trapping in modals (Tab/Shift+Tab cycling, focus save/restore)
- Added `role="dialog"`, `aria-modal="true"`, `aria-label`/`aria-labelledby` to all 4 modal components (FindingDetailModal, DetailModal, SearchModal, ConfirmDialog)
- Added `aria-hidden="true"` to decorative emoji icons in Navigation
- Added `aria-current="page"` to active navigation link
- Added `aria-live` regions to Toast notifications (polite for info, assertive for errors)
- Added `aria-label` to interactive elements: search input, theme toggle, logout button, new scan link

Closes #128

**Note: `needs-human-review`** — This issue was flagged for human review.

## Risk
Tier 1 — Frontend-only accessibility enhancement, no functional changes.

## Test plan
- [ ] Open any modal (Finding Detail, Detail, Search, Confirm Dialog) — Tab key should cycle within modal, not escape to background
- [ ] Close modal — focus should return to the element that opened it
- [ ] Screen reader (VoiceOver): Navigation announces page labels, not emoji icons
- [ ] Active nav link announces "current page"
- [ ] Toast notifications are announced by screen reader
- [ ] Login error is announced immediately (assertive)
- [ ] All modals announce their title/purpose when opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)