### PR TITLE
fix: validate WebSocket JWT auth and add proper admin role

### DIFF
--- a/modules/api/main.py
+++ b/modules/api/main.py
@@ -24,6 +24,7 @@ try:
             ("last_login", "NULL"),
             ("totp_secret", "NULL"),
             ("totp_enabled", "FALSE"),
+            ("is_admin", "FALSE"),
         ]:
             try:
                 type_map = {
@@ -33,6 +34,7 @@ try:
                     "last_login": f"TIMESTAMP {default}",
                     "totp_secret": f"VARCHAR {default}",
                     "totp_enabled": f"BOOLEAN DEFAULT {default}",
+                    "is_admin": f"BOOLEAN DEFAULT {default}",
                 }
                 col_type = type_map.get(col, f"VARCHAR {default}")
                 conn.execute(text(f"ALTER TABLE users ADD COLUMN IF NOT EXISTS {col} {col_type}"))

--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -15,6 +15,7 @@ class User(Base):
     hashed_password: Mapped[str] = mapped_column(String)
     plan: Mapped[str] = mapped_column(String, default="free")
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
     failed_attempts: Mapped[int] = mapped_column(Integer, default=0)
     locked_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_login: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/modules/api/routes/auth.py
+++ b/modules/api/routes/auth.py
@@ -36,9 +36,11 @@ def register(body: UserCreate, db: Session = Depends(get_db)):
     if db.query(User).filter(User.email == body.email.lower()).first():
         raise HTTPException(status_code=400, detail="Email already registered")
 
+    is_first_user = db.query(User).count() == 0
     user = User(
         email=body.email.lower().strip(),
         hashed_password=hash_password(body.password),
+        is_admin=is_first_user,
     )
     db.add(user)
     db.commit()
@@ -344,6 +346,7 @@ class UserUpdateRequest(BaseModel):
     email: str | None = None
     plan: str | None = None
     is_active: bool | None = None
+    is_admin: bool | None = None
 
 
 class AdminCreateUserRequest(BaseModel):
@@ -388,6 +391,8 @@ def admin_update_user(user_id: str, body: UserUpdateRequest, user: User = Depend
         target.plan = body.plan
     if body.is_active is not None:
         target.is_active = body.is_active
+    if body.is_admin is not None:
+        target.is_admin = body.is_admin
     db.commit()
     db.refresh(target)
     return target
@@ -449,6 +454,5 @@ def admin_disable_2fa(user_id: str, user: User = Depends(get_current_user), db: 
 
 
 def _require_admin(user: User, db: Session):
-    first_user = db.query(User).order_by(User.created_at.asc()).first()
-    if not first_user or first_user.id != user.id:
+    if not user.is_admin:
         raise HTTPException(status_code=403, detail="Admin access required")

--- a/modules/api/routes/dashboard.py
+++ b/modules/api/routes/dashboard.py
@@ -16,6 +16,9 @@ from modules.api.dashboard import (
     ChartDataGenerator,
 )
 from modules.api.models import User
+from jose import JWTError, jwt as jose_jwt
+from modules.api.auth import SECRET_KEY, ALGORITHM, is_token_blacklisted
+from modules.api.database import SessionLocal
 
 logger = logging.getLogger(__name__)
 
@@ -92,26 +95,41 @@ async def websocket_endpoint(
 ):
     """
     WebSocket endpoint for real-time dashboard updates.
-    Clients should connect with their JWT token as a query parameter.
+    Clients must connect with a valid JWT token as a query parameter.
     """
-    # Token validation would happen here in production
-    # For now, we accept the connection
-    
-    user_id = None
+    # Validate token before accepting connection
+    if not token:
+        await websocket.close(code=4001)
+        return
+
     try:
-        # In production, validate token and extract user_id
-        # For this implementation, we'll use the connection itself
-        await websocket.accept()
-        
-        # Client should send their user_id in first message
-        initial_message = await websocket.receive_text()
-        data = json.loads(initial_message)
-        user_id = data.get("user_id")
-        
-        if not user_id:
-            await websocket.send_json({"error": "user_id required"})
-            await websocket.close(code=4000)
+        payload = jose_jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = payload.get("sub")
+        token_type = payload.get("type")
+        if not user_id or token_type != "access":
+            await websocket.close(code=4001)
             return
+    except JWTError:
+        await websocket.close(code=4001)
+        return
+
+    if is_token_blacklisted(token):
+        await websocket.close(code=4001)
+        return
+
+    # Verify user exists and is active
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user or not user.is_active:
+            await websocket.close(code=4001)
+            return
+    finally:
+        db.close()
+
+    # Token is valid — accept connection
+    try:
+        await websocket.accept()
 
         # Register this connection
         await ws_manager.connect(websocket, user_id)
@@ -132,7 +150,7 @@ async def websocket_endpoint(
             try:
                 message = await websocket.receive_text()
                 data = json.loads(message)
-                
+
                 # Handle different message types
                 msg_type = data.get("type")
                 if msg_type == "ping":
@@ -141,7 +159,6 @@ async def websocket_endpoint(
                         {"type": "pong", "timestamp": data.get("timestamp")},
                     )
                 elif msg_type == "subscribe":
-                    # Client subscribing to specific updates
                     channel = data.get("channel")
                     logger.debug(f"User {user_id} subscribed to {channel}")
 
@@ -151,9 +168,8 @@ async def websocket_endpoint(
                 logger.error(f"Error processing message for user {user_id}: {e}")
 
     except WebSocketDisconnect:
-        if user_id:
-            ws_manager.disconnect(websocket, user_id)
-            logger.info(f"WebSocket disconnected for user {user_id}")
+        ws_manager.disconnect(websocket, user_id)
+        logger.info(f"WebSocket disconnected for user {user_id}")
     except Exception as e:
         logger.error(f"WebSocket error: {e}")
         try:

--- a/modules/api/routes/rate_limits.py
+++ b/modules/api/routes/rate_limits.py
@@ -121,11 +121,5 @@ async def get_rate_limit_config(
 
 
 def is_admin(user: User) -> bool:
-    """
-    Check if user is admin.
-    
-    This is a placeholder. Enhance with proper role-based access control.
-    """
-    # For now, admins are users who created the account before a certain date
-    # or have a special flag set (can be enhanced)
-    return True  # Allow for now, should be based on actual admin role
+    """Check if user has admin privileges."""
+    return user.is_admin

--- a/modules/api/schemas.py
+++ b/modules/api/schemas.py
@@ -75,6 +75,7 @@ class UserResponse(BaseModel):
     email: str
     plan: str
     is_active: bool = True
+    is_admin: bool = False
     failed_attempts: int = 0
     locked_until: datetime | None = None
     last_login: datetime | None = None


### PR DESCRIPTION
## Summary
- **WebSocket auth fix**: JWT token is now validated BEFORE accepting the WebSocket connection. Missing/invalid/blacklisted tokens are rejected with code 4001. User identity comes from JWT payload, not client messages.
- **Admin role model**: Added `is_admin` boolean column to User model with DB migration
- **First-user promotion**: First registered user is auto-promoted to admin
- **_require_admin() fix**: Now checks `user.is_admin` instead of fragile "first user by created_at" heuristic
- **is_admin() fix**: `rate_limits.py` placeholder replaced — was always returning `True`
- **Admin management**: Admins can promote/demote users via `PATCH /api/auth/users/{id}`

Closes #126

**NEEDS HUMAN REVIEW** — Tier 3 security fix touching critical paths (auth.py, models.py, WebSocket auth).

## Risk
Tier 3 — Critical path changes: auth, models, WebSocket authentication.

## Test plan
- [ ] Register first user → verify `is_admin=True` in DB
- [ ] Register second user → verify `is_admin=False`
- [ ] Connect to WebSocket without token → connection rejected (4001)
- [ ] Connect with invalid token → rejected
- [ ] Connect with valid token → accepted, receives welcome message
- [ ] Admin endpoints (list users, update user) work for admin
- [ ] Admin endpoints return 403 for non-admin users
- [ ] Rate limit admin endpoints return 403 for non-admin (was returning 200 for all)
- [ ] Existing login/2FA flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)