### PR TITLE
docs: add comprehensive API documentation and OpenAPI metadata

### DIFF
--- a/modules/api/main.py
+++ b/modules/api/main.py
@@ -101,9 +101,44 @@ except Exception:
     pass  # ES may not be ready yet; indices will be created on first use
 
 app = FastAPI(
-    title="Security Scanner API",
+    title="SSSAI Security Scanner API",
     version="0.2.0",
-    description="AI-powered autonomous security scanning, SEO analysis, and compliance monitoring platform",
+    description="""
+## AI-Powered Security Scanning Platform
+
+SSSAI provides autonomous security scanning with AI-driven analysis.
+
+### Authentication
+All endpoints require JWT bearer token authentication unless noted otherwise.
+1. Register: `POST /api/auth/register`
+2. Login: `POST /api/auth/login` → returns `access_token`
+3. Use token: `Authorization: Bearer <token>` header
+4. Refresh: `POST /api/auth/refresh` (uses refresh token cookie)
+
+### WebSocket
+Real-time updates via `ws://host/ws`. Send `{"type": "auth", "token": "<jwt>"}` after connecting.
+
+### Pagination
+List endpoints return `{"items": [...], "total": N, "skip": N, "limit": N, "has_next": bool, "has_prev": bool}`.
+Default: skip=0, limit=50, max=500.
+""",
+    openapi_tags=[
+        {"name": "auth", "description": "User registration, login, JWT tokens, 2FA, and admin user management"},
+        {"name": "scans", "description": "Create, list, and manage security scans. View reports and compare results"},
+        {"name": "findings", "description": "View and update finding status (false positive, accepted risk)"},
+        {"name": "monitors", "description": "Uptime monitors — create, list, get checks and stats"},
+        {"name": "schedules", "description": "Recurring scan schedules — create, update, delete, run now"},
+        {"name": "notifications", "description": "Notification channels — email, Slack, Discord, webhook"},
+        {"name": "reports", "description": "Report generation — PDF, HTML, executive briefs"},
+        {"name": "campaigns", "description": "Multi-target scan campaigns"},
+        {"name": "search", "description": "Global search across findings, scans, activity, and analytics"},
+        {"name": "dashboard", "description": "Dashboard stats, heatmaps, trends, and WebSocket updates"},
+        {"name": "tools", "description": "Available scanning tools and their capabilities"},
+        {"name": "posture", "description": "Security posture scoring and trends"},
+        {"name": "webhooks", "description": "Webhook configuration for external integrations"},
+        {"name": "export", "description": "Export findings and scans as CSV"},
+        {"name": "audit", "description": "Audit log viewing"},
+    ],
 )
 
 _ALLOWED_ORIGINS = os.environ.get("CORS_ORIGINS", "http://localhost:8000").split(",")

--- a/modules/api/routes/auth.py
+++ b/modules/api/routes/auth.py
@@ -29,6 +29,11 @@ GENERIC_AUTH_ERROR = "Invalid email or password"
 
 @router.post("/register", response_model=UserResponse)
 def register(body: UserCreate, db: Session = Depends(get_db)):
+    """Register a new user account.
+
+    The first registered user is automatically promoted to admin.
+    Password requirements: minimum 8 characters, must contain uppercase letter.
+    """
     pw_error = validate_password(body.password)
     if pw_error:
         raise HTTPException(status_code=400, detail=pw_error)
@@ -64,6 +69,11 @@ class TwoFactorVerifyRequest(BaseModel):
 
 @router.post("/login", response_model=LoginResponse)
 def login(body: UserCreate, response: Response, db: Session = Depends(get_db)):
+    """Authenticate and get JWT access token.
+
+    If 2FA is enabled, returns a temporary token with requires_2fa=true.
+    Use /verify-2fa with the temporary token and TOTP code to complete login.
+    """
     email = body.email.lower().strip()
 
     if check_rate_limit(email):
@@ -263,7 +273,7 @@ def disable_2fa(
 
 @router.post("/refresh", response_model=LoginResponse)
 def refresh_token(request: Request, response: Response, db: Session = Depends(get_db)):
-    """Issue a new access token using a valid refresh token."""
+    """Refresh an expired access token using the refresh token cookie."""
     raw_token = request.cookies.get("refresh_token")
     if not raw_token:
         auth = request.headers.get("authorization", "")
@@ -357,6 +367,7 @@ class AdminCreateUserRequest(BaseModel):
 
 @router.get("/users", response_model=list[UserResponse])
 def list_users(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """List all users (admin only)."""
     _require_admin(user, db)
     return db.query(User).order_by(User.created_at.asc()).all()
 

--- a/modules/api/routes/monitors.py
+++ b/modules/api/routes/monitors.py
@@ -29,6 +29,7 @@ def _paginated_response(items: list, total: int, skip: int, limit: int) -> dict:
 
 @router.post("/", response_model=MonitorResponse)
 def create_monitor(body: MonitorCreate, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Create a new uptime monitor for a target URL or domain."""
     try:
         # Check if monitor for this target already exists
         existing = db.query(Monitor).filter(
@@ -64,6 +65,7 @@ def list_monitors(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    """List all uptime monitors for the current user with pagination."""
     query = db.query(Monitor).filter(Monitor.user_id == user.id).order_by(Monitor.created_at.desc())
     total = query.count()
     items = query.offset(skip).limit(limit).all()

--- a/modules/api/routes/scans.py
+++ b/modules/api/routes/scans.py
@@ -39,6 +39,11 @@ def _paginated_response(items: list, total: int, skip: int, limit: int) -> dict:
 
 @router.post("/", response_model=ScanResponse)
 def create_scan(body: ScanCreate, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Create and queue a new security scan.
+
+    The scan is queued for processing by the worker service.
+    Supported scan types: security, adaptive, quick, api, ssl, headers, recon, vulnerability.
+    """
     scan = Scan(user_id=user.id, target=body.target, scan_type=body.scan_type, config=body.config)
     db.add(scan)
     db.commit()
@@ -60,6 +65,11 @@ def list_scans(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
+    """List all scans for the current user with pagination.
+
+    Returns paginated results sorted by creation date (newest first).
+    Query params: skip (default 0), limit (default 50, max 500).
+    """
     query = db.query(Scan).filter(Scan.user_id == user.id).order_by(Scan.created_at.desc())
     total = query.count()
     items = query.offset(skip).limit(limit).all()
@@ -155,6 +165,7 @@ def get_scan(scan_id: str, user: User = Depends(get_current_user), db: Session =
 
 @router.get("/{scan_id}/report")
 def get_report(scan_id: str, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """Get the full scan report including findings, risk score, and recommendations."""
     scan = db.query(Scan).filter(Scan.id == scan_id, Scan.user_id == user.id).first()
     if not scan:
         raise HTTPException(status_code=404, detail="Scan not found")
@@ -167,7 +178,7 @@ def get_report(scan_id: str, user: User = Depends(get_current_user), db: Session
 
 @router.post("/{scan_id}/retry")
 def retry_scan(scan_id: str, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    """Retry a failed or completed scan.
+    """Retry a failed or completed scan with context from the previous attempt.
 
     For failed scans: re-queues the entire scan.
     For completed scans with errors: creates a follow-up scan that focuses on
@@ -253,7 +264,7 @@ def verify_scan(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Create a targeted re-scan to verify whether original findings have been remediated.
+    """Create a verification scan to re-test findings from a completed scan.
 
     The verification scan tests ONLY the specific findings from the original scan,
     not a full re-scan. Each finding receives a status of verified_fixed,
@@ -332,7 +343,7 @@ def verify_scan(
 
 @router.post("/{scan_id}/stop")
 def stop_scan(scan_id: str, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
-    """Stop a running scan by setting a Redis signal that the agent checks each iteration."""
+    """Stop a running scan by sending a stop signal via Redis."""
     scan = db.query(Scan).filter(Scan.id == scan_id, Scan.user_id == user.id).first()
     if not scan:
         raise HTTPException(status_code=404, detail="Scan not found")
@@ -377,7 +388,7 @@ def compare_scans(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Compare findings between a current scan and a baseline scan."""
+    """Compare findings between two scans to identify new, resolved, and changed vulnerabilities."""
     current_scan = db.query(Scan).filter(Scan.id == scan_id, Scan.user_id == user.id).first()
     if not current_scan:
         raise HTTPException(status_code=404, detail="Current scan not found")


### PR DESCRIPTION
## Summary
- Enhanced FastAPI app metadata with detailed description covering auth flow, WebSocket protocol, and pagination conventions
- Added 15 `openapi_tags` with descriptions for all route groups
- Added docstrings to key endpoints in scans, auth, and monitors routes
- Swagger UI at `/docs` now shows organized, well-documented API

Closes #145

## Test plan
- [ ] Visit `http://localhost:8000/docs` — Swagger UI shows organized tags with descriptions
- [ ] Each tag group (auth, scans, monitors, etc.) has a description
- [ ] Endpoints within groups have docstrings visible
- [ ] API description at top explains auth flow and pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)