### PR TITLE
fix: design polish — spacing, contrast, visual consistency

### DIFF
--- a/frontend/src/components/Breadcrumbs.css
+++ b/frontend/src/components/Breadcrumbs.css
@@ -15,13 +15,13 @@
 }
 
 .breadcrumb-separator {
-  color: var(--app-text-muted, #555);
+  color: var(--app-text-muted, #888);
   margin: 0 4px;
   user-select: none;
 }
 
 .breadcrumb-link {
-  color: var(--app-text-secondary, #888);
+  color: var(--app-text-secondary, #9ca3af);
   text-decoration: none;
   transition: color 0.15s;
 }

--- a/frontend/src/components/FindingDetailModal.jsx
+++ b/frontend/src/components/FindingDetailModal.jsx
@@ -21,7 +21,7 @@ export default function FindingDetailModal({ finding, onClose }) {
     low: '#44ff44',
     info: '#4a9eff',
   }
-  const color = severityColors[finding.severity] || '#888'
+  const color = severityColors[finding.severity] || '#b0b4c0'
 
   return (
     <div className="fdm-overlay" onClick={onClose} role="dialog" aria-modal="true">

--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -46,7 +46,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: var(--app-text-muted, #555);
+  color: var(--app-text-muted, #888);
 }
 
 .nav-group-items {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,8 +14,8 @@
   /* App-level theme tokens (dark defaults) */
   --app-bg: #0f1117;
   --app-text: #e8eaed;
-  --app-text-secondary: #888;
-  --app-text-muted: #666;
+  --app-text-secondary: #9ca3af;
+  --app-text-muted: #888;
   --card-bg: #1a1d27;
   --card-border: #2a2d3a;
   --card-hover-bg: #252c3a;
@@ -83,8 +83,8 @@
 
   --app-bg: #f5f6fa;
   --app-text: #1a1d27;
-  --app-text-secondary: #6b7280;
-  --app-text-muted: #9ca3af;
+  --app-text-secondary: #4b5563;
+  --app-text-muted: #6b7280;
   --card-bg: #ffffff;
   --card-border: #e2e4e9;
   --card-hover-bg: #f0f1f5;

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -146,6 +146,11 @@
   color: #ff4a4a;
 }
 
+.scan-detail-sep {
+  color: var(--app-text-muted, #888);
+  margin: 0 4px;
+}
+
 .timestamp {
   color: var(--app-text-muted);
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -179,15 +179,23 @@ function Dashboard({ token }) {
                 <div className="scan-title">{scan.target || 'Unknown'}</div>
                 <div className="scan-details">
                   <span className={`status ${scan.status}`}>{scan.status}</span>
+                  <span className="scan-detail-sep">|</span>
                   <span className="scan-type">{scan.scan_type || 'security'}</span>
                   {scan.findings_count > 0 && (
-                    <span className="scan-findings">{scan.findings_count} findings</span>
+                    <>
+                      <span className="scan-detail-sep">|</span>
+                      <span className="scan-findings">{scan.findings_count} findings</span>
+                    </>
                   )}
                   {scan.risk_score != null && (
-                    <span className={`scan-risk ${scan.risk_score >= 30 ? 'high' : scan.risk_score >= 15 ? 'medium' : 'low'}`}>
-                      Risk: {scan.risk_score}
-                    </span>
+                    <>
+                      <span className="scan-detail-sep">|</span>
+                      <span className={`scan-risk ${scan.risk_score >= 30 ? 'high' : scan.risk_score >= 15 ? 'medium' : 'low'}`}>
+                        Risk: {scan.risk_score}
+                      </span>
+                    </>
                   )}
+                  <span className="scan-detail-sep">|</span>
                   <span className="timestamp">{new Date(scan.created_at).toLocaleDateString()}</span>
                 </div>
               </div>

--- a/frontend/src/pages/FindingsPage.css
+++ b/frontend/src/pages/FindingsPage.css
@@ -373,7 +373,7 @@
 .modal-header h2 {
   margin: 0;
   font-size: 20px;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .close-btn {

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -14,7 +14,7 @@ const FINDING_STATUSES = [
   { value: 'confirmed', label: 'Confirmed', color: '#ff8844', bg: '#4a3a2a' },
   { value: 'in_progress', label: 'In Progress', color: '#ffcc44', bg: '#4a4a2a' },
   { value: 'resolved', label: 'Resolved', color: '#44ff44', bg: '#2a4a2a' },
-  { value: 'false_positive', label: 'False Positive', color: '#999', bg: '#2a2d3a' },
+  { value: 'false_positive', label: 'False Positive', color: '#b0b4c0', bg: '#2a2d3a' },
   { value: 'accepted_risk', label: 'Accepted Risk', color: '#bb77ff', bg: '#3a2a4a' },
 ]
 

--- a/frontend/src/pages/QueuePage.jsx
+++ b/frontend/src/pages/QueuePage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import './StubPage.css'
+import './Common.css'
 import './QueuePage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''

--- a/frontend/src/pages/RemediationPage.css
+++ b/frontend/src/pages/RemediationPage.css
@@ -14,7 +14,7 @@
 .summary-critical .count { color: #ff4444; }
 .summary-high .count { color: #ff8844; }
 .summary-medium .count { color: #ffaa44; }
-.summary-low .count { color: #44ff44; }
+.summary-low .count { color: #22c55e; }
 
 /* View Tabs */
 
@@ -94,13 +94,13 @@
 
 .finding-card:hover {
   border-color: var(--card-hover-border);
-  background: #1e2130;
+  background: var(--card-hover-bg);
 }
 
 .finding-card.severity-border-critical { border-left-color: #ff4444; }
 .finding-card.severity-border-high { border-left-color: #ff8844; }
 .finding-card.severity-border-medium { border-left-color: #ffaa44; }
-.finding-card.severity-border-low { border-left-color: #44ff44; }
+.finding-card.severity-border-low { border-left-color: #22c55e; }
 .finding-card.severity-border-info { border-left-color: #4a9eff; }
 
 .finding-card-header {
@@ -347,7 +347,7 @@
 .bucket-header h3 {
   margin: 0;
   font-size: 16px;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .bucket-count {

--- a/frontend/src/pages/RemediationPage.jsx
+++ b/frontend/src/pages/RemediationPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/ToastContext'
+import './Common.css'
 import './RemediationPage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''

--- a/frontend/src/pages/ScansPage.css
+++ b/frontend/src/pages/ScansPage.css
@@ -89,11 +89,11 @@
 }
 
 .scans-table tr:hover td {
-  background: #1e2230;
+  background: var(--card-hover-bg);
 }
 
 .scan-target {
-  color: #fff;
+  color: var(--app-text);
   font-weight: 500;
   max-width: 300px;
   overflow: hidden;

--- a/frontend/src/pages/SchedulesPage.jsx
+++ b/frontend/src/pages/SchedulesPage.jsx
@@ -276,8 +276,8 @@ function SchedulesPage({ token }) {
                     }} />
                     {sched.is_active ? 'Active' : 'Paused'}
                   </td>
-                  <td style={{ ...tdStyle, color: '#888' }}>{formatDate(sched.next_run_at)}</td>
-                  <td style={{ ...tdStyle, color: '#888' }}>{formatDate(sched.last_run_at)}</td>
+                  <td style={{ ...tdStyle, color: '#b0b4c0' }}>{formatDate(sched.next_run_at)}</td>
+                  <td style={{ ...tdStyle, color: '#b0b4c0' }}>{formatDate(sched.last_run_at)}</td>
                   <td style={tdStyle}>
                     {sched.run_count || 0}
                     {sched.max_runs ? ` / ${sched.max_runs}` : ''}
@@ -357,7 +357,7 @@ const btnSecondaryStyle = {
   ...btnStyle,
   background: 'transparent',
   borderColor: '#2a2d3a',
-  color: '#888',
+  color: '#b0b4c0',
 }
 
 const formContainerStyle = {
@@ -382,7 +382,7 @@ const fieldStyle = {
 
 const labelStyle = {
   fontSize: 12,
-  color: '#888',
+  color: '#b0b4c0',
   fontWeight: 600,
   textTransform: 'uppercase',
   letterSpacing: '0.5px',
@@ -409,7 +409,7 @@ const tableStyle = {
 const thStyle = {
   padding: '12px 16px',
   textAlign: 'left',
-  color: '#888',
+  color: '#b0b4c0',
   fontSize: 11,
   fontWeight: 600,
   textTransform: 'uppercase',
@@ -433,7 +433,7 @@ const badgeStyle = {
   background: '#2a3040',
   borderRadius: 4,
   fontSize: 11,
-  color: '#aaa',
+  color: '#ccc',
   textTransform: 'uppercase',
 }
 
@@ -450,7 +450,7 @@ const actionBtnStyle = {
   background: 'transparent',
   border: '1px solid #2a2d3a',
   borderRadius: 4,
-  color: '#aaa',
+  color: '#ccc',
   fontSize: 11,
   cursor: 'pointer',
   whiteSpace: 'nowrap',

--- a/frontend/src/pages/StubPage.css
+++ b/frontend/src/pages/StubPage.css
@@ -20,7 +20,7 @@
 .feature-card h2 {
   margin: 0 0 12px;
   font-size: 18px;
-  color: #fff;
+  color: var(--app-text);
 }
 
 .feature-card p {

--- a/frontend/src/pages/WebhooksPage.jsx
+++ b/frontend/src/pages/WebhooksPage.jsx
@@ -66,9 +66,9 @@ function WebhooksPage({ token }) {
           <table style={{ width: '100%', borderCollapse: 'collapse' }}>
             <thead>
               <tr style={{ background: '#111420', borderBottom: '1px solid #2a2d3a' }}>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>URL</th>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>Event</th>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#888' }}>Status</th>
+                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>URL</th>
+                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>Event</th>
+                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>Status</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- **Spacing fixes**: Remediation summary stats and Queue counters now stack label/number vertically (was "Total Findings27")
- **Dashboard separators**: Pipe delimiters between scan card details (status | type | findings | risk | date)
- **Contrast improvements across 15 files**:
  - Light theme: `--app-text-secondary` darkened from `#6b7280` to `#4b5563`, `--app-text-muted` from `#9ca3af` to `#6b7280`
  - Dark theme: `--app-text-muted` brightened from `#666` to `#888`
  - Replaced hardcoded low-contrast colors (#888, #999, #aaa) with CSS variables or higher-contrast values
  - Fixed inline style colors in SchedulesPage, WebhooksPage, FindingsPage

Closes #148

## Risk
Tier 1 — CSS and JSX styling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)