### PR TITLE
feat: normalize all tables with shared CSS classes

### DIFF
--- a/frontend/src/pages/QueuePage.jsx
+++ b/frontend/src/pages/QueuePage.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import '../styles/tables.css'
 import './StubPage.css'
 import './Common.css'
-import './QueuePage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
 
@@ -62,30 +62,32 @@ function QueuePage({ token }) {
           <Link to="/scans/new" className="empty-state-cta">Start a New Scan</Link>
         </div>
       ) : (
-        <table className="queue-table">
-          <thead>
-            <tr>
-              <th>Target</th>
-              <th>Status</th>
-              <th>Position</th>
-              <th>ETA</th>
-            </tr>
-          </thead>
-          <tbody>
-            {queue.map((scan, idx) => (
-              <tr key={scan.id}>
-                <td>{scan.target || 'N/A'}</td>
-                <td>
-                  <span className={`queue-status-badge ${scan.status}`}>
-                    {scan.status}
-                  </span>
-                </td>
-                <td className="muted">{idx + 1}</td>
-                <td className="muted">~5 min</td>
+        <div className="data-table-wrapper">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Target</th>
+                <th>Status</th>
+                <th>Position</th>
+                <th>ETA</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {queue.map((scan, idx) => (
+                <tr key={scan.id}>
+                  <td>{scan.target || 'N/A'}</td>
+                  <td>
+                    <span className={`badge ${scan.status}`}>
+                      {scan.status}
+                    </span>
+                  </td>
+                  <td className="cell-muted">{idx + 1}</td>
+                  <td className="cell-muted">~5 min</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/SchedulesPage.jsx
+++ b/frontend/src/pages/SchedulesPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import ConfirmDialog from '../components/ConfirmDialog'
 import DetailModal from '../components/DetailModal'
+import '../styles/tables.css'
 import './StubPage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
@@ -245,69 +246,67 @@ function SchedulesPage({ token }) {
           <button onClick={() => setShowForm(true)} className="empty-state-cta">Create Schedule</button>
         </div>
       ) : (
-        <div style={{ overflowX: 'auto' }}>
-          <table style={tableStyle}>
+        <div className="data-table-wrapper">
+          <table className="data-table">
             <thead>
-              <tr style={{ background: '#111420', borderBottom: '1px solid #2a2d3a' }}>
-                <th style={thStyle}>Target</th>
-                <th style={thStyle}>Type</th>
-                <th style={thStyle}>Frequency</th>
-                <th style={thStyle}>Status</th>
-                <th style={thStyle}>Next Run</th>
-                <th style={thStyle}>Last Run</th>
-                <th style={thStyle}>Runs</th>
-                <th style={{ ...thStyle, textAlign: 'right' }}>Actions</th>
+              <tr>
+                <th>Target</th>
+                <th>Type</th>
+                <th>Frequency</th>
+                <th>Status</th>
+                <th>Next Run</th>
+                <th>Last Run</th>
+                <th>Runs</th>
+                <th style={{ textAlign: 'right' }}>Actions</th>
               </tr>
             </thead>
             <tbody>
               {schedules.map(sched => (
-                <tr key={sched.id} style={rowStyle} onClick={() => setSelectedSchedule(sched)}>
-                  <td style={tdStyle}>
+                <tr key={sched.id} onClick={() => setSelectedSchedule(sched)}>
+                  <td>
                     <span style={{ color: '#4a9eff' }}>{sched.target}</span>
                   </td>
-                  <td style={tdStyle}>
-                    <span style={badgeStyle}>{sched.scan_type}</span>
+                  <td>
+                    <span className="badge">{sched.scan_type}</span>
                   </td>
-                  <td style={tdStyle}>{frequencyLabel(sched.cron_expression)}</td>
-                  <td style={tdStyle}>
-                    <span style={{
-                      ...statusDotStyle,
-                      background: sched.is_active ? '#44ff44' : '#666',
-                    }} />
-                    {sched.is_active ? 'Active' : 'Paused'}
+                  <td>{frequencyLabel(sched.cron_expression)}</td>
+                  <td>
+                    <span className={`badge ${sched.is_active ? 'active' : 'paused'}`}>
+                      {sched.is_active ? 'Active' : 'Paused'}
+                    </span>
                   </td>
-                  <td style={{ ...tdStyle, color: '#b0b4c0' }}>{formatDate(sched.next_run_at)}</td>
-                  <td style={{ ...tdStyle, color: '#b0b4c0' }}>{formatDate(sched.last_run_at)}</td>
-                  <td style={tdStyle}>
+                  <td className="cell-muted">{formatDate(sched.next_run_at)}</td>
+                  <td className="cell-muted">{formatDate(sched.last_run_at)}</td>
+                  <td>
                     {sched.run_count || 0}
                     {sched.max_runs ? ` / ${sched.max_runs}` : ''}
                   </td>
-                  <td style={{ ...tdStyle, textAlign: 'right' }} onClick={e => e.stopPropagation()}>
-                    <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                  <td style={{ textAlign: 'right' }} onClick={e => e.stopPropagation()}>
+                    <div className="table-actions">
                       <button
                         onClick={() => handleToggle(sched.id)}
-                        style={actionBtnStyle}
+                        className="table-action-btn"
                         title={sched.is_active ? 'Pause' : 'Resume'}
                       >
                         {sched.is_active ? 'Pause' : 'Resume'}
                       </button>
                       <button
                         onClick={() => handleRunNow(sched.id)}
-                        style={{ ...actionBtnStyle, borderColor: '#2a5a3a', color: '#6fdf8f' }}
+                        className="table-action-btn success"
                         title="Run scan now"
                       >
                         Run Now
                       </button>
                       <button
                         onClick={() => startEdit(sched)}
-                        style={actionBtnStyle}
+                        className="table-action-btn"
                         title="Edit schedule"
                       >
                         Edit
                       </button>
                       <button
                         onClick={() => setConfirmingDelete(sched.id)}
-                        style={{ ...actionBtnStyle, borderColor: '#5a2a2a', color: '#ff6b6b' }}
+                        className="table-action-btn danger"
                         title="Delete schedule"
                       >
                         Delete
@@ -342,6 +341,7 @@ function SchedulesPage({ token }) {
   )
 }
 
+/* Form styles (kept as inline style objects — table styles moved to tables.css) */
 const btnStyle = {
   padding: '8px 20px',
   background: '#2a3d50',
@@ -396,64 +396,6 @@ const inputStyle = {
   color: '#e8eaed',
   fontSize: 13,
   outline: 'none',
-}
-
-const tableStyle = {
-  width: '100%',
-  borderCollapse: 'collapse',
-  background: '#1a1d27',
-  borderRadius: 8,
-  overflow: 'hidden',
-}
-
-const thStyle = {
-  padding: '12px 16px',
-  textAlign: 'left',
-  color: '#b0b4c0',
-  fontSize: 11,
-  fontWeight: 600,
-  textTransform: 'uppercase',
-  letterSpacing: '0.5px',
-}
-
-const tdStyle = {
-  padding: '12px 16px',
-  color: '#e8eaed',
-  fontSize: 13,
-  borderBottom: '1px solid #2a2d3a',
-}
-
-const rowStyle = {
-  cursor: 'pointer',
-  transition: 'background 0.15s',
-}
-
-const badgeStyle = {
-  padding: '2px 8px',
-  background: '#2a3040',
-  borderRadius: 4,
-  fontSize: 11,
-  color: '#ccc',
-  textTransform: 'uppercase',
-}
-
-const statusDotStyle = {
-  display: 'inline-block',
-  width: 8,
-  height: 8,
-  borderRadius: '50%',
-  marginRight: 8,
-}
-
-const actionBtnStyle = {
-  padding: '4px 10px',
-  background: 'transparent',
-  border: '1px solid #2a2d3a',
-  borderRadius: 4,
-  color: '#ccc',
-  fontSize: 11,
-  cursor: 'pointer',
-  whiteSpace: 'nowrap',
 }
 
 export default SchedulesPage

--- a/frontend/src/pages/WebhooksPage.jsx
+++ b/frontend/src/pages/WebhooksPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import '../styles/tables.css'
 import './StubPage.css'
 
 const API_BASE = import.meta.env.VITE_API_URL || ''
@@ -63,26 +64,28 @@ function WebhooksPage({ token }) {
       {webhooks.length > 0 && (
         <div className="webhooks-list">
           <h2>Configured Webhooks</h2>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            <thead>
-              <tr style={{ background: '#111420', borderBottom: '1px solid #2a2d3a' }}>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>URL</th>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>Event</th>
-                <th style={{ padding: '12px 16px', textAlign: 'left', color: '#b0b4c0' }}>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {webhooks.map(wh => (
-                <tr key={wh.id} style={{ borderBottom: '1px solid #2a2d3a' }}>
-                  <td style={{ padding: '12px 16px', color: '#e8eaed', fontSize: '12px' }}>
-                    {wh.url?.substring(0, 50)}...
-                  </td>
-                  <td style={{ padding: '12px 16px', color: '#e8eaed' }}>{wh.event || 'N/A'}</td>
-                  <td style={{ padding: '12px 16px', color: '#44ff44' }}>Active</td>
+          <div className="data-table-wrapper">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>URL</th>
+                  <th>Event</th>
+                  <th>Status</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {webhooks.map(wh => (
+                  <tr key={wh.id}>
+                    <td className="cell-mono cell-truncate">
+                      {wh.url?.substring(0, 50)}...
+                    </td>
+                    <td>{wh.event || 'N/A'}</td>
+                    <td><span className="badge active">Active</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/styles/tables.css
+++ b/frontend/src/styles/tables.css
@@ -1,0 +1,138 @@
+/* ─── Shared Table Styles ─────────────────────────────────────────── */
+
+.data-table-wrapper {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.data-table th {
+  text-align: left;
+  padding: 10px 16px;
+  color: var(--app-text-secondary);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--card-border);
+  background: var(--card-bg);
+  white-space: nowrap;
+}
+
+.data-table td {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--card-border);
+  color: var(--app-text);
+  font-size: 13px;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tbody tr:hover td {
+  background: var(--card-hover-bg);
+}
+
+.data-table tbody tr {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+/* Status badges */
+.badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge-completed, .badge.completed { background: #1a3a2a; color: #44cc88; }
+.badge-running, .badge.running { background: #1a2a3a; color: #44aaff; }
+.badge-queued, .badge.queued, .badge-pending, .badge.pending { background: #2a2a1a; color: #ccaa44; }
+.badge-failed, .badge.failed { background: #2a1a1a; color: #ff6666; }
+.badge-active, .badge.active { background: #1a3a2a; color: #44cc88; }
+.badge-paused, .badge.paused { background: #2a2a1a; color: #ccaa44; }
+
+/* Action buttons in tables */
+.table-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.table-action-btn {
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  color: var(--app-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.table-action-btn:hover {
+  border-color: var(--app-text-secondary);
+  color: var(--app-text);
+}
+
+.table-action-btn.danger {
+  border-color: #5a2a2a;
+  color: #ff6b6b;
+}
+
+.table-action-btn.danger:hover {
+  background: #2a1a1a;
+}
+
+.table-action-btn.success {
+  border-color: #2a5a3a;
+  color: #6fdf8f;
+}
+
+.table-action-btn.success:hover {
+  background: #1a2a1a;
+}
+
+.table-action-link {
+  color: #00d4ff;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.table-action-link:hover {
+  text-decoration: underline;
+}
+
+/* Cell helpers */
+.cell-truncate {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cell-nowrap {
+  white-space: nowrap;
+}
+
+.cell-muted {
+  color: var(--app-text-secondary);
+}
+
+.cell-mono {
+  font-family: monospace;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- Created shared `tables.css` with `.data-table`, `.badge`, `.table-action-btn` classes
- Refactored SchedulesPage: removed 7 inline style objects, uses shared CSS
- Refactored QueuePage: replaced custom styles with shared classes
- Refactored WebhooksPage: replaced all inline styles with shared classes
- All tables now have consistent headers, row hover, badges, and action buttons

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)