### PR TITLE
fix: wire real Claude action into issue-implementer workflow

### DIFF
--- a/.github/workflows/issue-implementer.yml
+++ b/.github/workflows/issue-implementer.yml
@@ -336,12 +336,17 @@ jobs:
             }
 
       # ================================================================
-      # Step 11: Agent execution (placeholder)
+      # Step 11: Agent execution
       # ================================================================
       - name: Run AI agent
         if: steps.guard.outputs.should-implement == 'true'
         id: agent
-        run: echo "::notice::AI agent execution would run here"
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.build-prompt.outputs.prompt }}
+          claude_args: '--model claude-opus-4-6 --max-turns 100 --allowedTools "Read,Write,Edit,MultiEdit,Glob,Grep,Bash"'
+          allowed_bots: 'github-actions'
 
       # ================================================================
       # Step 12: Check for file changes


### PR DESCRIPTION
## Summary
- The `Run AI agent` step in `.github/workflows/issue-implementer.yml` was a placeholder: `run: echo "::notice::AI agent execution would run here"`. Implementer workflows reported success without invoking Claude, leaving no file changes and therefore no PRs for issues #167-#174.
- Replace the placeholder with `anthropics/claude-code-action@v1`, mirroring the existing `issue-planner.yml` pattern but enabling write tools (`Write`, `Edit`, `MultiEdit`) so the agent can actually make code changes.
- Bump `--max-turns` from 30 (planner) to 100 as requested — implementer tasks are larger than planning and need more headroom.

## Change
```diff
-      - name: Run AI agent
-        if: steps.guard.outputs.should-implement == 'true'
-        id: agent
-        run: echo "::notice::AI agent execution would run here"
+      - name: Run AI agent
+        if: steps.guard.outputs.should-implement == 'true'
+        id: agent
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.build-prompt.outputs.prompt }}
+          claude_args: '--model claude-opus-4-6 --max-turns 100 --allowedTools "Read,Write,Edit,MultiEdit,Glob,Grep,Bash"'
+          allowed_bots: 'github-actions'
```

## Test plan
- [ ] Merge this PR, then manually dispatch the workflow against an existing unimplemented issue (e.g. #174) via `workflow_dispatch`
- [ ] Verify the `Run AI agent` step now uses the Anthropic action instead of echoing
- [ ] Verify a branch `cf/*` is created and a PR is opened with actual code changes
- [ ] Re-label issues #167-#173 with `agent:implement` once #174 is verified to unblock the remaining implementations
- [ ] Monitor workflow duration — 100 turns on Opus can be expensive; adjust down if needed after observing a few runs

## Risk: Tier 2
Modifies CI automation that can write code and open PRs. Reviewer should confirm:
- Protected-file revert step (Step 13) still safeguards `.github/workflows/*`, `harness.config.json`, `CLAUDE.md`, and lock files — it does (lines 376-393, unchanged)
- `claude_code_oauth_token` secret is configured in repo settings

Fixes the issue where implementer actions "ran" (reported success in Actions tab) but produced no PRs.