### PR TITLE
feat(agent): auto-recall memory on adapt_plan (#174)

### DIFF
--- a/modules/agent/memory.py
+++ b/modules/agent/memory.py
@@ -1,0 +1,296 @@
+"""
+Cross-scan memory with per-tenant isolation and retrieval-augmented planning (#174).
+
+Two public entry points:
+  - recall_for_planning(scan_context, top_k=5) — called from adapt_plan handler
+    to pull in prior experience on similar target classes
+  - auto_store_scan_summary(scan_id, user_id, target, scan_type, report) — called
+    from the worker after a scan completes to persist a structured summary
+
+Storage: Postgres `scan_memory` table. User_id is the isolation key — no
+memory is ever returned across users.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any, Iterable
+
+log = logging.getLogger(__name__)
+
+_DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql+psycopg2://scanner:scanner@postgres:5432/scanner",
+)
+
+# Minimum technology-overlap ratio required to include a memory in recall.
+_MIN_TECH_OVERLAP = 0.25
+
+
+# ── Database helpers ────────────────────────────────────────────────────────
+
+def _get_engine():
+    try:
+        from sqlalchemy import create_engine
+        return create_engine(_DB_URL, pool_pre_ping=True)
+    except Exception as e:
+        log.warning("Memory DB unavailable: %s", e)
+        return None
+
+
+def _ensure_schema(engine) -> None:
+    """Idempotently ensure the scan_memory table and the user_id column exist."""
+    from sqlalchemy import text
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE IF NOT EXISTS scan_memory (
+                id SERIAL PRIMARY KEY,
+                content TEXT NOT NULL,
+                memory_type VARCHAR(50) NOT NULL DEFAULT 'guide',
+                tags TEXT[] DEFAULT '{}',
+                metadata JSONB DEFAULT '{}',
+                scan_id VARCHAR(100),
+                target VARCHAR(500),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """))
+        # Additive migrations for #174
+        conn.execute(text("ALTER TABLE scan_memory ADD COLUMN IF NOT EXISTS user_id VARCHAR(100)"))
+        conn.execute(text("ALTER TABLE scan_memory ADD COLUMN IF NOT EXISTS target_class VARCHAR(200)"))
+        conn.execute(text("ALTER TABLE scan_memory ADD COLUMN IF NOT EXISTS scan_type VARCHAR(50)"))
+        conn.execute(text("ALTER TABLE scan_memory ADD COLUMN IF NOT EXISTS technologies TEXT[]"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_scan_memory_user_id ON scan_memory(user_id)"))
+        conn.execute(text("CREATE INDEX IF NOT EXISTS idx_scan_memory_target_class ON scan_memory(target_class)"))
+
+
+# ── Target-class derivation ────────────────────────────────────────────────
+
+def _normalize_tech(tech: str) -> str:
+    return tech.lower().strip().replace(" ", "_")[:40]
+
+
+def derive_target_class(technologies: Iterable[str]) -> str:
+    """Sort + normalize + join tech list — deterministic identifier."""
+    seen: list[str] = []
+    for t in technologies or []:
+        n = _normalize_tech(str(t))
+        if n and n not in seen:
+            seen.append(n)
+    seen.sort()
+    return "+".join(seen[:8])  # cap at 8 for sane keys
+
+
+def _extract_technologies(attack_surface: dict | None) -> list[str]:
+    if not attack_surface:
+        return []
+    techs = attack_surface.get("technologies") or []
+    out: list[str] = []
+    for t in techs:
+        if isinstance(t, str):
+            out.append(t)
+        elif isinstance(t, dict):
+            name = t.get("name") or t.get("tech") or t.get("technology")
+            if name:
+                out.append(str(name))
+    return out
+
+
+# ── Recall ─────────────────────────────────────────────────────────────────
+
+def recall_for_planning(scan_context: dict | None, top_k: int = 5) -> str:
+    """Return a formatted 'Prior experience' block for injection into adapt_plan,
+    or an empty string if no memory is available / recall fails / no user_id.
+
+    Per-tenant strict isolation: fails closed if user_id is missing.
+    """
+    if not scan_context:
+        return ""
+    user_id = scan_context.get("user_id") or scan_context.get("_user_id")
+    if not user_id:
+        return ""  # Fail closed — never leak across tenants
+
+    attack_surface = scan_context.get("_attack_surface") or {}
+    technologies = _extract_technologies(attack_surface)
+    scan_type = scan_context.get("scan_type", "")
+
+    if not technologies:
+        return ""
+
+    engine = _get_engine()
+    if not engine:
+        return ""
+    try:
+        _ensure_schema(engine)
+        from sqlalchemy import text
+        target_class = derive_target_class(technologies)
+
+        with engine.connect() as conn:
+            rows = conn.execute(text("""
+                SELECT content, memory_type, technologies, target_class, scan_type,
+                       created_at, metadata
+                FROM scan_memory
+                WHERE user_id = :user_id
+                  AND memory_type = 'scan_summary'
+                ORDER BY created_at DESC
+                LIMIT 100
+            """), {"user_id": user_id}).fetchall()
+
+        if not rows:
+            return ""
+
+        # Score: tech overlap * 0.7 + scan-type match * 0.2 + exact-class * 0.1
+        scored: list[tuple[float, dict]] = []
+        req_tech_set = {_normalize_tech(t) for t in technologies}
+        for row in rows:
+            row_tech = set((row[2] or []))
+            if not req_tech_set:
+                overlap = 0.0
+            else:
+                overlap = len(req_tech_set & row_tech) / len(req_tech_set)
+            if overlap < _MIN_TECH_OVERLAP:
+                continue
+            score = overlap * 0.7
+            if row[4] == scan_type:
+                score += 0.2
+            if row[3] == target_class:
+                score += 0.1
+            scored.append((score, {
+                "content": row[0],
+                "memory_type": row[1],
+                "technologies": list(row_tech),
+                "target_class": row[3],
+                "scan_type": row[4],
+                "created_at": row[5].isoformat() if row[5] else None,
+                "metadata": row[6] or {},
+                "score": round(score, 3),
+            }))
+
+        scored.sort(key=lambda kv: kv[0], reverse=True)
+        top = [entry for _, entry in scored[:top_k]]
+        if not top:
+            return ""
+
+        lines = [
+            "## Prior experience on similar targets",
+            f"(auto-recalled {len(top)} relevant memories for target_class={target_class})",
+            "",
+        ]
+        for i, mem in enumerate(top, 1):
+            lines.append(f"### {i}. score={mem['score']} scan_type={mem['scan_type']}")
+            lines.append(f"Technologies: {', '.join(mem['technologies'][:8])}")
+            lines.append(mem["content"][:1200])
+            lines.append("")
+        return "\n".join(lines)
+
+    except Exception as e:
+        log.warning("recall_for_planning failed: %s", e)
+        return ""
+
+
+# ── Auto-store ─────────────────────────────────────────────────────────────
+
+def _summarize_findings(findings: list[dict]) -> list[dict]:
+    """Keep only non-PII structural bits for persistence."""
+    summary = []
+    for f in (findings or [])[:50]:
+        if not isinstance(f, dict):
+            continue
+        summary.append({
+            "title":    f.get("title") or f.get("name") or "",
+            "severity": f.get("severity", "unknown"),
+            "category": f.get("category") or f.get("cwe") or "",
+            "confirmed": (f.get("verification_status") == "confirmed"),
+            "owasp":    f.get("owasp", ""),
+        })
+    return summary
+
+
+def _extract_working_payloads(findings: list[dict]) -> list[str]:
+    payloads: list[str] = []
+    for f in (findings or [])[:50]:
+        if not isinstance(f, dict):
+            continue
+        p = f.get("poc_payload") or f.get("payload") or f.get("evidence_snippet")
+        if p and isinstance(p, str) and len(p) < 500:
+            payloads.append(p)
+    return payloads[:20]
+
+
+def auto_store_scan_summary(
+    scan_id: str,
+    user_id: str | None,
+    target: str,
+    scan_type: str,
+    report: dict,
+) -> bool:
+    """Persist a structured summary of a completed scan for future recall.
+
+    Idempotent: if a summary for this scan_id already exists, it is replaced.
+    Returns True if stored, False otherwise.
+    """
+    if not user_id:
+        log.info("auto_store_scan_summary skipped for scan %s: no user_id", scan_id)
+        return False
+    findings = report.get("findings") or []
+    if not findings:
+        log.info("auto_store_scan_summary skipped for scan %s: no findings", scan_id)
+        return False
+
+    engine = _get_engine()
+    if not engine:
+        return False
+
+    try:
+        _ensure_schema(engine)
+        from sqlalchemy import text
+
+        attack_surface = report.get("attack_surface") or {}
+        technologies = _extract_technologies(attack_surface)
+        target_class = derive_target_class(technologies)
+
+        payload = {
+            "target":             target,
+            "target_class":       target_class,
+            "technologies":       technologies[:20],
+            "scan_type":          scan_type,
+            "findings_summary":   _summarize_findings(findings),
+            "working_payloads":   _extract_working_payloads(findings),
+            "risk_score":         report.get("risk_score", 0),
+            "finding_count":      len(findings),
+            "timestamp":          time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        content = json.dumps(payload, sort_keys=True, default=str)
+
+        with engine.begin() as conn:
+            # Idempotency: remove prior summary for this scan_id
+            conn.execute(text(
+                "DELETE FROM scan_memory WHERE scan_id = :sid AND memory_type = 'scan_summary'"
+            ), {"sid": scan_id})
+            conn.execute(text("""
+                INSERT INTO scan_memory
+                    (content, memory_type, tags, metadata, scan_id, target,
+                     user_id, target_class, scan_type, technologies)
+                VALUES
+                    (:content, 'scan_summary', :tags, :metadata, :scan_id, :target,
+                     :user_id, :target_class, :scan_type, :techs)
+            """), {
+                "content":      content,
+                "tags":         [scan_type, target_class][:10],
+                "metadata":     json.dumps({"auto_stored": True}),
+                "scan_id":      scan_id,
+                "target":       target,
+                "user_id":      user_id,
+                "target_class": target_class,
+                "scan_type":    scan_type,
+                "techs":        [_normalize_tech(t) for t in technologies[:20]],
+            })
+        log.info("Stored scan_summary memory for scan %s (user=%s, class=%s)",
+                 scan_id, user_id, target_class)
+        return True
+
+    except Exception as e:
+        log.warning("auto_store_scan_summary failed for scan %s: %s", scan_id, e)
+        return False

--- a/modules/agent/scan_agent.py
+++ b/modules/agent/scan_agent.py
@@ -631,7 +631,11 @@ def _handle_credential_leak_check(input: dict, scan_context: dict | None) -> str
 # ── AI-first adaptive tool handlers ─────────────────────────────────────
 
 def _handle_adapt_plan(input: dict, scan_context: dict | None) -> str:
-    """Record a plan revision and log it for audit trail."""
+    """Record a plan revision and log it for audit trail.
+
+    Auto-recalls prior experience from cross-scan memory on the first revision
+    (Issue #174). Subsequent revisions skip recall to avoid noise.
+    """
     try:
         if not scan_context:
             scan_context = {}
@@ -674,6 +678,24 @@ def _handle_adapt_plan(input: dict, scan_context: dict | None) -> str:
         result = f"Plan revision #{revision_num} recorded ({len(input['plan_steps'])} steps). Reason: {input['reason']}"
         if available:
             result += f"\nKnowledge modules ready to load: {', '.join(available)}. Use load_knowledge to inject them."
+
+        # Auto-recall memory on first plan revision (#174) — retrieval-augmented planning.
+        # Per-tenant strict isolation enforced inside recall_for_planning.
+        if revision_num == 1:
+            try:
+                from modules.agent.memory import recall_for_planning
+                recalled = recall_for_planning(scan_context, top_k=5)
+                if recalled:
+                    result += "\n\n" + recalled
+                    if scan_id:
+                        _log_activity(scan_id, {
+                            "type": "memory_recall",
+                            "message": "Injected prior experience on similar targets",
+                            "timestamp": time.strftime("%H:%M:%S"),
+                        })
+            except Exception as mem_err:
+                log.warning("auto-recall failed for scan %s: %s", scan_id, mem_err)
+
         return result
 
     except Exception as e:
@@ -2815,6 +2837,7 @@ def run_scan(scan_id: str, target: str, scan_type: str, config: dict | None = No
         "scan_id": scan_id,
         "target": target,
         "scan_type": scan_type,
+        "user_id": (config or {}).get("user_id"),
         "_token_tracker": token_tracker,
         "_budget": budget,
     }

--- a/modules/worker/__init__.py
+++ b/modules/worker/__init__.py
@@ -210,6 +210,12 @@ def main():
             log.info("Starting scan %s: %s (%s)", scan_id, target, scan_type)
             _update_scan_status(scan_id, "running")
 
+            # Inject user_id into run_scan config so the agent can use it for
+            # per-tenant memory recall (#174) without re-querying the DB.
+            _user_id = _get_scan_user_id(scan_id)
+            if _user_id:
+                config = {**(config or {}), "user_id": _user_id}
+
             try:
                 report = run_scan(scan_id, target, scan_type, config)
                 raw_findings = report.get("findings", [])
@@ -241,6 +247,13 @@ def main():
                         run_posture_update(scan_id, posture_user_id, target, raw_findings)
                 except Exception as posture_err:
                     log.warning("Posture score update failed for scan %s: %s", scan_id, posture_err)
+
+                # Auto-store scan summary in cross-scan memory for future recall (#174)
+                try:
+                    from modules.agent.memory import auto_store_scan_summary
+                    auto_store_scan_summary(scan_id, _user_id, target, scan_type, report)
+                except Exception as mem_err:
+                    log.warning("auto_store_scan_summary failed for scan %s: %s", scan_id, mem_err)
             except Exception as e:
                 log.exception("Scan %s failed: %s", scan_id, e)
                 _update_scan_status(scan_id, "failed")


### PR DESCRIPTION
Closes #174

## Summary
- New `modules/agent/memory.py` with `recall_for_planning()` and `auto_store_scan_summary()`
- `_handle_adapt_plan` in scan_agent.py auto-invokes recall on first plan revision and appends "Prior experience on similar targets" to the tool result
- Worker auto-stores structured scan summary (technologies, findings summary, working payloads) after each scan completes
- Per-tenant isolation: `user_id` threaded through `config['user_id']` → scan_context → memory queries. Fails closed (returns empty) when user_id missing.
- Tech-overlap scoring with 25% minimum; top-5 memories returned
- Additive DB migrations: ALTER TABLE ... ADD COLUMN IF NOT EXISTS user_id, target_class, scan_type, technologies

## Test plan
- [x] Python syntax check
- [ ] Docker rebuild
- [ ] Run two scans on similar targets as same user; verify second scan's adapt_plan output contains "Prior experience" block
- [ ] Run a third scan as a different user; verify no cross-tenant recall
- [ ] DB migration: confirm ALTER TABLE IF NOT EXISTS idempotency

## Risk: Tier 1
- Fail-closed isolation pattern
- No auth/DB schema breakage on user-facing tables
- Touches critical path `scan_agent.py` (adapt_plan handler only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)