### PR TITLE
feat(agent): mandatory exploitation gate (#167)

### DIFF
--- a/modules/agent/exploitation_gate.py
+++ b/modules/agent/exploitation_gate.py
@@ -1,0 +1,206 @@
+"""
+Mandatory exploitation gate: prove-or-demote (Issue #167).
+
+Before a scan report is finalized, each high/critical finding must either:
+  (a) carry a successful read-only PoC, or
+  (b) be automatically demoted to a lower severity with an explicit
+      "unverified_unexploitable" marker.
+
+The gate is wired into scan_agent's `report` tool handler so the agent
+cannot bypass it by simply calling report early.
+
+Policy (configurable via env):
+  EXPLOITATION_GATE_POLICY = "strict" | "lenient" | "off"
+    strict  — critical/high both require PoC or are demoted
+    lenient — critical demoted on failure; high left as-is but marked
+    off     — no gating (skip entirely)
+
+Non-destructive policy enforced: the gate only invokes existing PoC
+generators in modules.agent.exploitation_engine which are already
+constrained to read-only techniques (SELECT, id, whoami, alert(1),
+path traversal to /etc/hostname, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# Severity ladder for demotion
+_SEVERITY_ORDER = ["info", "low", "medium", "high", "critical"]
+
+
+def _demote(severity: str) -> str:
+    try:
+        i = _SEVERITY_ORDER.index(severity.lower())
+    except ValueError:
+        return "info"
+    return _SEVERITY_ORDER[max(0, i - 1)]
+
+
+# Safe finding classes we are willing to auto-exploit.
+# Destructive or high-risk categories (e.g. RCE with shell spawn) are
+# excluded — the agent must prove those manually with read-only techniques.
+_GATE_ELIGIBLE_CLASSES = {
+    "sqli", "sql_injection", "sql injection",
+    "xss", "cross-site scripting", "stored xss", "reflected xss",
+    "idor", "insecure direct object reference",
+    "ssrf", "server-side request forgery",
+    "path_traversal", "path traversal", "lfi", "local file inclusion",
+    "open_redirect", "open redirect",
+    "cors", "cors misconfiguration",
+    "auth_bypass", "authentication bypass",
+    "command_injection", "command injection", "os command injection",
+    "xxe", "xml external entity",
+}
+
+
+def _classify(finding: dict) -> str:
+    """Try to map a finding to one of our eligible classes, or return "" if
+    ineligible (we skip the gate for ineligible classes)."""
+    blob = " ".join(
+        str(finding.get(k, "")) for k in ("category", "type", "cwe", "title", "name")
+    ).lower()
+    for cls in _GATE_ELIGIBLE_CLASSES:
+        if cls in blob:
+            return cls
+    return ""
+
+
+def _policy() -> str:
+    return os.environ.get("EXPLOITATION_GATE_POLICY", "strict").lower()
+
+
+def _per_finding_timeout() -> float:
+    try:
+        return float(os.environ.get("EXPLOITATION_GATE_PER_FINDING_SEC", "30"))
+    except ValueError:
+        return 30.0
+
+
+def _attempt_poc(target: str, finding: dict) -> dict:
+    """Attempt a single PoC against the finding. Returns a structured result.
+
+    Never raises — all failures degrade into attempted_failed with an error note.
+    """
+    result = {
+        "exploitation_status": "attempted_failed",
+        "poc_payload": None,
+        "poc_response_evidence": None,
+        "poc_reproduction_steps": [],
+        "poc_error": None,
+    }
+    try:
+        # Lazy import — avoid loading heavy exploit module if gate is off
+        from modules.agent.exploitation_engine import ExploitationFramework
+
+        framework = ExploitationFramework(target=target)
+        started = time.time()
+        report = framework.exploit_finding(finding)
+        elapsed = time.time() - started
+
+        result["poc_duration_seconds"] = round(elapsed, 2)
+        if report and report.overall_success:
+            # Pull first successful payload for evidence
+            winning = next(
+                (r for r in report.exploit_results if getattr(r, "success", False)),
+                None,
+            )
+            if winning:
+                result["exploitation_status"] = "proven"
+                result["poc_payload"] = getattr(winning, "payload", None) or getattr(winning, "raw_payload", None)
+                result["poc_response_evidence"] = getattr(winning, "evidence", None) or getattr(winning, "response_snippet", None)
+                result["poc_reproduction_steps"] = getattr(winning, "steps", []) or []
+            else:
+                result["exploitation_status"] = "proven"
+        else:
+            result["poc_error"] = "No payload succeeded"
+    except Exception as e:
+        result["poc_error"] = f"{type(e).__name__}: {e}"
+        log.warning("PoC attempt failed for finding %s: %s", finding.get("id"), e)
+    return result
+
+
+def enforce_exploitation_gate(report: dict, target: str, scan_id: str = "") -> dict:
+    """Apply the exploitation gate to all eligible findings in-place.
+
+    Returns the mutated report with a new `exploitation_gate` metadata block.
+    Always returns even if gate is disabled.
+    """
+    policy = _policy()
+    gate_meta: dict[str, Any] = {
+        "policy": policy,
+        "attempted": 0,
+        "proven": 0,
+        "demoted": 0,
+        "skipped_ineligible": 0,
+        "skipped_already_marked": 0,
+        "skipped_insufficient_severity": 0,
+    }
+
+    if policy == "off":
+        report["exploitation_gate"] = gate_meta
+        return report
+
+    findings = report.get("findings") or []
+    if not findings:
+        report["exploitation_gate"] = gate_meta
+        return report
+
+    gate_start = time.time()
+    # Overall hard timeout so the gate can't run forever on a noisy scan
+    try:
+        gate_budget = float(os.environ.get("EXPLOITATION_GATE_TOTAL_SEC", "300"))
+    except ValueError:
+        gate_budget = 300.0
+
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        severity = (f.get("severity") or "").lower()
+        # Gate applies to high/critical; medium/low left untouched in strict.
+        # In lenient, only critical is gated.
+        if policy == "strict" and severity not in ("high", "critical"):
+            gate_meta["skipped_insufficient_severity"] += 1
+            continue
+        if policy == "lenient" and severity != "critical":
+            gate_meta["skipped_insufficient_severity"] += 1
+            continue
+
+        if f.get("exploitation_status") in ("proven", "attempted_failed"):
+            gate_meta["skipped_already_marked"] += 1
+            continue
+
+        cls = _classify(f)
+        if not cls:
+            gate_meta["skipped_ineligible"] += 1
+            # Mark so the reader knows we considered it but didn't attempt
+            f["exploitation_status"] = "skipped_ineligible"
+            continue
+
+        if time.time() - gate_start > gate_budget:
+            log.warning("Exploitation gate budget exhausted; skipping remaining findings")
+            f["exploitation_status"] = "skipped_gate_timeout"
+            continue
+
+        gate_meta["attempted"] += 1
+        attempt = _attempt_poc(target, f)
+        f.update(attempt)
+
+        if attempt["exploitation_status"] == "proven":
+            gate_meta["proven"] += 1
+        else:
+            # Demote severity — strict demotes high/critical; lenient only critical
+            original = f.get("severity", "info")
+            f["severity_original"] = original
+            f["severity"] = _demote(original)
+            f["verification_status"] = "unverified_unexploitable"
+            gate_meta["demoted"] += 1
+
+    gate_meta["duration_seconds"] = round(time.time() - gate_start, 2)
+    report["exploitation_gate"] = gate_meta
+    return report

--- a/modules/agent/scan_agent.py
+++ b/modules/agent/scan_agent.py
@@ -3252,6 +3252,28 @@ def run_scan(scan_id: str, target: str, scan_type: str, config: dict | None = No
                     if result == "__REPORT__":
                         _record_phase(scan_context, "reporting")
                         report = block.input
+
+                        # ── Mandatory exploitation gate (#167) ──
+                        # Runs BEFORE persistence. Attempts PoC on high/critical
+                        # findings; demotes those that cannot be proven with
+                        # read-only techniques.
+                        try:
+                            from modules.agent.exploitation_gate import enforce_exploitation_gate
+                            report = enforce_exploitation_gate(report, target, scan_id)
+                            gate = report.get("exploitation_gate", {})
+                            if gate.get("attempted", 0) > 0:
+                                _log_activity(scan_id, {
+                                    "type": "exploitation_gate",
+                                    "message": (
+                                        f"Exploitation gate: attempted={gate['attempted']} "
+                                        f"proven={gate['proven']} demoted={gate['demoted']} "
+                                        f"({gate.get('duration_seconds', 0)}s)"
+                                    ),
+                                    "timestamp": time.strftime("%H:%M:%S"),
+                                })
+                        except Exception as gate_err:
+                            log.warning("Exploitation gate failed for scan %s: %s", scan_id, gate_err)
+
                         report["scan_metadata"] = {
                             **report.get("scan_metadata", {}),
                             "duration_seconds": int(time.time() - start_time),


### PR DESCRIPTION
Closes #167

## Summary
- New `modules/agent/exploitation_gate.py` with `enforce_exploitation_gate()`
- Wired into `scan_agent.py` report tool handler before persistence
- Uses existing `ExploitationFramework` for read-only PoC attempts
- Demotes findings that can't be proven; tags `verification_status=unverified_unexploitable`
- Policy configurable: strict (default) / lenient / off
- Per-finding (30s) and total (300s) timeouts

## Risk: Tier 2 — changes report tool semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)