### PR TITLE
chore(agent): flag autonomous_agent.py as inactive (#173)

### DIFF
--- a/modules/agent/autonomous_agent.py
+++ b/modules/agent/autonomous_agent.py
@@ -1,9 +1,23 @@
 """
 Autonomous Security Agent - Core Decision Engine (Issue #50)
 
-This module implements the autonomous agent that can audit targets completely
-without human input. It uses a state machine to manage scan phases, Claude to
-make intelligent decisions, and a learning feedback loop to improve over time.
+STATUS (Issue #173): This module is NOT the active scan entry point.
+Production scans run through `modules/agent/scan_agent.py:run_scan` which
+is invoked by `modules/worker/__init__.py`. This state-machine-based
+implementation was built as an alternative architecture and remains
+in-tree pending a decision to either:
+
+  (A) Migrate scan_agent.py's battle-tested capabilities (checkpointing,
+      reflector, loop-detector, 40-tool registry) into this state machine
+      and flip `USE_AUTONOMOUS_AGENT=true` to cut over, OR
+  (B) Remove this module entirely and evolve scan_agent.py in place.
+
+Feature flag `USE_AUTONOMOUS_AGENT` (see modules/config.py) currently
+defaults to `false`. No code path reads it — it exists for future
+migration work. See issue #173 for context.
+
+This module implements an autonomous agent using a state machine for
+scan phases, Claude-driven decisions, and a learning feedback loop.
 
 Architecture:
   ├─ StateManager: Manages scan state machine transitions

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,5 +1,5 @@
 """
-Central configuration for AI model selection.
+Central configuration for AI model selection and agent feature flags.
 
 Tier system (Issue #171):
   AI_MODEL_DISCOVERY  — routine tool dispatch, discovery, HTTP parsing (fast/cheap)
@@ -13,6 +13,11 @@ Back-compat:
 Extended thinking:
   EXTENDED_THINKING_BUDGET  — thinking token budget on Sonnet/Opus calls (0 disables)
   Haiku models do NOT support extended thinking and skip the thinking block.
+
+Feature flags:
+  USE_AUTONOMOUS_AGENT — state-machine scan entry point in
+                          modules/agent/autonomous_agent.py. Default false —
+                          reserved for #173 migration (not currently wired).
 
 Environment overrides:
   AI_MODEL_DISCOVERY=claude-haiku-4-5-20251001
@@ -42,6 +47,13 @@ AI_MODEL = AI_MODEL_DISCOVERY
 
 # Extended thinking budget (tokens). 0 disables. Only applied on Sonnet/Opus.
 EXTENDED_THINKING_BUDGET = int(os.environ.get("EXTENDED_THINKING_BUDGET", "8000"))
+
+# Feature flag for the state-machine agent (Issue #173) — NOT yet wired into
+# the worker. Reserved for the future migration from while-loop to state
+# machine. Leave false unless you are actively working on that migration.
+USE_AUTONOMOUS_AGENT = os.environ.get("USE_AUTONOMOUS_AGENT", "false").lower() in (
+    "1", "true", "yes", "on",
+)
 
 # Cost per 1M tokens: (input_cost, output_cost)
 _PRICING = {


### PR DESCRIPTION
Closes #173

## Summary
- Adds STATUS block to `autonomous_agent.py` making inactive status explicit
- Adds `USE_AUTONOMOUS_AGENT` env flag to `config.py` (default false, currently unread)
- No production behavior change

## Decision taken
Option B-preliminary: keep in tree, flag as inactive. Full deletion or full Option A migration can follow once the new primitives (exploitation gate, critic, parallel hypotheses) stabilize on scan_agent.py. This commit does NOT delete code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)