### PR TITLE
fix(agent): disable extended thinking by default + correct posture args

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -45,8 +45,12 @@ AI_MODEL_LIGHT = os.environ.get("AI_MODEL_LIGHT", "claude-haiku-4-5-20251001")
 # Back-compat alias
 AI_MODEL = AI_MODEL_DISCOVERY
 
-# Extended thinking budget (tokens). 0 disables. Only applied on Sonnet/Opus.
-EXTENDED_THINKING_BUDGET = int(os.environ.get("EXTENDED_THINKING_BUDGET", "8000"))
+# Extended thinking budget (tokens). Default 0 = disabled.
+# Enabling thinking on every main-loop turn with high budget triggers
+# multi-minute turn latency on Sonnet 4.6 — avoid that unless the target
+# justifies the spend. Recommended values when enabled: 2000-4000 tokens.
+# Set to 8000+ only for heavy reasoning-intensive one-off runs.
+EXTENDED_THINKING_BUDGET = int(os.environ.get("EXTENDED_THINKING_BUDGET", "0"))
 
 # Feature flag for the state-machine agent (Issue #173) — NOT yet wired into
 # the worker. Reserved for the future migration from while-loop to state

--- a/modules/worker/__init__.py
+++ b/modules/worker/__init__.py
@@ -241,10 +241,13 @@ def main():
 
                 # Update security posture score after scan completes
                 try:
-                    posture_user_id = _get_scan_user_id(scan_id)
+                    posture_user_id = _user_id or _get_scan_user_id(scan_id)
                     if posture_user_id:
                         from modules.agent.posture_score import run_posture_update
-                        run_posture_update(scan_id, posture_user_id, target, raw_findings)
+                        run_posture_update(
+                            scan_id, target, posture_user_id,
+                            raw_findings, score,
+                        )
                 except Exception as posture_err:
                     log.warning("Posture score update failed for scan %s: %s", scan_id, posture_err)
 


### PR DESCRIPTION
Observed on live scan: Sonnet 4.6 + 8000 thinking tokens → 2min per main-loop turn, making scans impractically slow. Default thinking to 0 (opt-in via env for heavy runs). Also fix run_posture_update argument order (was silently broken).