### PR TITLE
feat: scan recommendations, auto-queue discoveries, one-click start

### DIFF
--- a/frontend/src/pages/ScanDetailsPage.jsx
+++ b/frontend/src/pages/ScanDetailsPage.jsx
@@ -275,6 +275,12 @@ function ScanDetailsPage({ token }) {
         >
           Logs
         </button>
+        <button
+          className={`bg-transparent border-b-2 px-4 py-3 text-sm font-semibold cursor-pointer transition ${activeTab === 'recommendations' ? 'border-cyan-400 text-cyan-400' : 'border-transparent text-gray-500 hover:text-gray-300'}`}
+          onClick={() => setActiveTab('recommendations')}
+        >
+          Next Steps {(report?.recommended_next_scans?.length || 0) > 0 ? `(${report.recommended_next_scans.length})` : ''}
+        </button>
       </div>
 
       <div>
@@ -381,6 +387,69 @@ function ScanDetailsPage({ token }) {
         {activeTab === 'logs' && (
           <div className="p-5">
             <pre className="bg-gray-950 border border-gray-700 rounded-xl p-4 font-mono text-xs text-cyan-400 max-h-96 overflow-auto leading-relaxed">{logs || 'No logs available. Logs are available during and shortly after scan execution.'}</pre>
+          </div>
+        )}
+
+        {activeTab === 'recommendations' && (
+          <div className="p-5">
+            {(() => {
+              const recs = report?.recommended_next_scans || [];
+              const discovered = report?.discovered_targets || [];
+              const all = [...recs, ...discovered];
+              if (all.length === 0) {
+                return <p className="text-gray-500 text-center py-10">No recommendations from this scan.</p>;
+              }
+              return (
+                <div className="space-y-3">
+                  {all.map((rec, idx) => (
+                    <div key={idx} className="bg-gray-800/30 border border-gray-700 rounded-xl p-4">
+                      <div className="flex justify-between items-start">
+                        <div className="flex-1">
+                          <div className="text-sm text-white font-medium">{rec.target}</div>
+                          <div className="text-xs text-gray-400 mt-1">{rec.reason}</div>
+                          {rec.what_to_look_for && (
+                            <div className="text-xs text-gray-500 mt-1">Look for: {rec.what_to_look_for}</div>
+                          )}
+                          <div className="flex gap-2 mt-2">
+                            <span className="text-[10px] px-2 py-0.5 rounded bg-cyan-900/40 text-cyan-300">{rec.scan_type || 'security'}</span>
+                            {rec.priority && (
+                              <span className={`text-[10px] px-2 py-0.5 rounded ${rec.priority === 'high' ? 'bg-red-900/40 text-red-300' : rec.priority === 'low' ? 'bg-gray-700 text-gray-400' : 'bg-yellow-900/40 text-yellow-300'}`}>{rec.priority}</span>
+                            )}
+                            {rec.auto_queued && (
+                              <span className="text-[10px] px-2 py-0.5 rounded bg-green-900/40 text-green-300">auto-queued</span>
+                            )}
+                          </div>
+                        </div>
+                        {!rec.auto_queued && (
+                          <button
+                            onClick={async () => {
+                              try {
+                                const resp = await fetch(`${API_BASE}/api/scans/${scanId}/start-recommended`, {
+                                  method: 'POST',
+                                  headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+                                  body: JSON.stringify({ target: rec.target, scan_type: rec.scan_type || 'security', reason: rec.reason }),
+                                });
+                                if (resp.ok) {
+                                  const data = await resp.json();
+                                  alert(`Scan queued: ${data.scan_id}`);
+                                } else {
+                                  alert('Failed to queue scan');
+                                }
+                              } catch (e) {
+                                alert('Error: ' + e.message);
+                              }
+                            }}
+                            className="px-3 py-1.5 bg-cyan-600 hover:bg-cyan-500 text-white text-xs font-semibold rounded transition ml-3 whitespace-nowrap"
+                          >
+                            Start Scan
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
           </div>
         )}
       </div>

--- a/modules/agent/prompts/master.txt
+++ b/modules/agent/prompts/master.txt
@@ -201,7 +201,25 @@ Before reporting, review ALL findings and identify how individual vulnerabilitie
 
 Include `attack_chains[]` in your `report` call. If no chains exist, include an empty array.
 
-### Phase 4: Report
+### Phase 3.7: Infrastructure Discovery & Auto-Queue
+
+Throughout the scan, watch for NEW infrastructure targets discovered in:
+- Response headers revealing internal hostnames (X-Backend-Server, Via, X-Forwarded-For)
+- DNS records pointing to other hosts (CNAME, MX, NS)
+- API responses referencing other services (database hostnames, message brokers, cache servers)
+- JavaScript source revealing internal API gateways or CDN origins
+- Subdomains with open services (admin panels, monitoring dashboards, CI/CD)
+- Certificate SANs listing additional domains
+- Redirect chains pointing to other hosts
+
+When you discover a new target worth scanning:
+1. Call `queue_discovery_scan` with the target, scan type, and reason
+2. The system will queue it automatically for scanning after the current scan
+3. Each discovered target gets its own scan with full autonomous execution
+
+This creates an **expanding scan network** — each scan can spawn follow-up scans as it discovers infrastructure. The operator can see all queued discovery scans in the UI.
+
+### Phase 4: Report with Actionable Next Steps
 
 Call the `report` tool with comprehensive findings. Your report MUST include:
 - All findings with severity, category, evidence, remediation
@@ -209,6 +227,23 @@ Call the `report` tool with comprehensive findings. Your report MUST include:
 - OWASP/CWE/CVE mappings where applicable
 - Attack chains from Phase 3.5 (even if empty array)
 - An improvement roadmap prioritized by risk
+- **`recommended_next_scans`** — a list of recommended follow-up scans. For each:
+  ```json
+  {
+    "target": "db.internal.example.com",
+    "scan_type": "security",
+    "reason": "Database server hostname discovered in X-Backend-Server header",
+    "priority": "high",
+    "what_to_look_for": "Open ports, default credentials, version disclosure, backup exposure"
+  }
+  ```
+
+  Include recommendations for:
+  - Any infrastructure targets you discovered but didn't scan (different hosts, subdomains)
+  - Deeper scans on the same target with different scan types (e.g., ran security → recommend pentest)
+  - Authenticated scans if you found login forms but didn't have credentials
+  - Periodic re-scans for findings that may change over time (SSL certs, DNS, etc.)
+  - Specific vulnerability classes that need manual testing (business logic, race conditions)
 
 ## Available Tools (80+)
 

--- a/modules/agent/scan_agent.py
+++ b/modules/agent/scan_agent.py
@@ -328,6 +328,9 @@ def handle_tool(name: str, input: dict, scan_context: dict | None = None) -> str
     elif name == "fork_hypothesis_branches":
         return _handle_fork_hypothesis_branches(input, scan_context)
 
+    elif name == "queue_discovery_scan":
+        return _handle_queue_discovery_scan(input, scan_context)
+
     elif name == "get_session_headers":
         return _handle_get_session_headers(scan_context)
 
@@ -827,6 +830,104 @@ def _handle_fork_hypothesis_branches(input: dict, scan_context: dict | None) -> 
         return _json.dumps(result, default=str)[:30_000]
     except Exception as e:
         return f"ERROR: fork_hypothesis_branches failed: {e}"
+
+
+def _handle_queue_discovery_scan(input: dict, scan_context: dict | None) -> str:
+    """Queue a new scan for infrastructure discovered during the current scan.
+
+    The agent calls this when it discovers a new target worth scanning — e.g.
+    a DB server hostname in a header, a subdomain with open ports, an API
+    gateway on a different host. Only queues if auto_queue_discoveries is
+    enabled in the scan config OR if the agent explicitly calls this tool.
+    """
+    try:
+        target = input.get("target", "").strip()
+        if not target:
+            return "ERROR: target is required"
+        scan_type = input.get("scan_type", "security")
+        reason = input.get("reason", "Discovered during parent scan")
+        priority = input.get("priority", "normal")
+
+        if not scan_context:
+            return "ERROR: no scan context"
+
+        parent_scan_id = scan_context.get("scan_id", "")
+        user_id = scan_context.get("user_id")
+        parent_target = scan_context.get("target", "")
+
+        # Prevent scanning the same target as the parent
+        if target.rstrip("/") == parent_target.rstrip("/"):
+            return f"Skipped: {target} is the same as the current scan target."
+
+        # Queue via Redis + DB
+        import uuid
+        from sqlalchemy import create_engine, text
+        db_url = os.environ.get("DATABASE_URL", "")
+        if not db_url or not user_id:
+            # Store as recommendation instead of queueing
+            scan_context.setdefault("_discovered_targets", []).append({
+                "target": target,
+                "scan_type": scan_type,
+                "reason": reason,
+                "priority": priority,
+                "auto_queued": False,
+            })
+            return f"Stored as recommendation (no DB/user_id to queue): {target}"
+
+        new_scan_id = str(uuid.uuid4())
+        engine = create_engine(db_url, pool_pre_ping=True)
+        with engine.begin() as conn:
+            conn.execute(text("""
+                INSERT INTO scans (id, user_id, target, scan_type, status, created_at, config, findings_count)
+                VALUES (:id, :user_id, :target, :scan_type, 'queued', NOW(), :config, 0)
+            """), {
+                "id": new_scan_id,
+                "user_id": user_id,
+                "target": target,
+                "scan_type": scan_type,
+                "config": json.dumps({
+                    "parent_scan_id": parent_scan_id,
+                    "discovery_reason": reason,
+                    "auto_queued": True,
+                }),
+            })
+
+        queue = get_queue()
+        queue.send("scan-jobs", {
+            "scan_id": new_scan_id,
+            "target": target,
+            "scan_type": scan_type,
+            "config": {
+                "parent_scan_id": parent_scan_id,
+                "discovery_reason": reason,
+                "auto_queued": True,
+            },
+        })
+
+        scan_context.setdefault("_discovered_targets", []).append({
+            "target": target,
+            "scan_type": scan_type,
+            "reason": reason,
+            "priority": priority,
+            "auto_queued": True,
+            "scan_id": new_scan_id,
+        })
+
+        _log_activity(parent_scan_id, {
+            "type": "discovery_scan_queued",
+            "target": target,
+            "scan_type": scan_type,
+            "reason": reason,
+            "new_scan_id": new_scan_id,
+            "timestamp": time.strftime("%H:%M:%S"),
+        })
+        _post_agent_chat(parent_scan_id,
+            f"Queued discovery scan: {target} ({scan_type}) — {reason}",
+            "status")
+
+        return f"Queued scan {new_scan_id} for {target} ({scan_type}). Reason: {reason}"
+    except Exception as e:
+        return f"ERROR: queue_discovery_scan failed: {e}"
 
 
 def _handle_load_knowledge(input: dict, scan_context: dict | None) -> str:
@@ -3702,6 +3803,10 @@ def run_scan(scan_id: str, target: str, scan_type: str, config: dict | None = No
             )
     except Exception as gate_err:
         log.warning("Exploitation gate failed for scan %s: %s", scan_id, gate_err)
+
+    # ── Attach discovered targets from mid-scan auto-queuing ──
+    if scan_context.get("_discovered_targets"):
+        report["discovered_targets"] = scan_context["_discovered_targets"]
 
     # ── Store report ──
     storage.put_json(f"scans/{scan_id}/report.json", report)

--- a/modules/agent/tools.py
+++ b/modules/agent/tools.py
@@ -1438,4 +1438,39 @@ SUBAGENT_TOOLS = [
             "required": [],
         },
     },
+    {
+        "name": "queue_discovery_scan",
+        "description": (
+            "Queue a NEW scan for infrastructure you discovered during the current "
+            "scan. Call this when you find a new target worth scanning — e.g. a DB "
+            "server hostname in a response header, an internal API gateway on a "
+            "different host, a subdomain with open admin panels, a cloud metadata "
+            "endpoint, etc. The new scan runs after the current one completes. "
+            "Only call for targets DIFFERENT from the current scan target."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "URL or hostname of the discovered target",
+                },
+                "scan_type": {
+                    "type": "string",
+                    "description": "Scan type for the new target (default: security)",
+                    "enum": ["security", "pentest", "recon", "api_security", "full"],
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Why this target should be scanned (what you discovered)",
+                },
+                "priority": {
+                    "type": "string",
+                    "description": "Priority: high (critical infra), normal, low (informational)",
+                    "enum": ["high", "normal", "low"],
+                },
+            },
+            "required": ["target", "reason"],
+        },
+    },
 ]

--- a/modules/api/routes/scans.py
+++ b/modules/api/routes/scans.py
@@ -385,6 +385,58 @@ def verify_scan(
     }
 
 
+@router.post("/{scan_id}/start-recommended")
+def start_recommended_scan(
+    scan_id: str,
+    body: dict,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Start a recommended follow-up scan from a completed scan's recommendations.
+
+    Body: {"target": "...", "scan_type": "security", "reason": "..."}
+    """
+    parent = db.query(Scan).filter(Scan.id == scan_id, Scan.user_id == user.id).first()
+    if not parent:
+        raise HTTPException(status_code=404, detail="Parent scan not found")
+
+    target = body.get("target", "").strip()
+    if not target:
+        raise HTTPException(status_code=400, detail="target is required")
+
+    scan_type = body.get("scan_type", "security")
+    reason = body.get("reason", "Recommended by parent scan")
+
+    scan = Scan(
+        user_id=user.id,
+        target=target,
+        scan_type=scan_type,
+        config={
+            "parent_scan_id": scan_id,
+            "discovery_reason": reason,
+            "recommended": True,
+        },
+    )
+    db.add(scan)
+    db.commit()
+    db.refresh(scan)
+
+    get_queue().send("scan-jobs", {
+        "scan_id": scan.id,
+        "target": scan.target,
+        "scan_type": scan.scan_type,
+        "config": scan.config or {},
+    })
+
+    return {
+        "scan_id": scan.id,
+        "target": target,
+        "scan_type": scan_type,
+        "parent_scan_id": scan_id,
+        "status": "queued",
+    }
+
+
 @router.post("/{scan_id}/stop")
 def stop_scan(scan_id: str, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     """Stop a running scan by sending a stop signal via Redis."""


### PR DESCRIPTION
## Summary
- Agent can call `queue_discovery_scan` mid-scan to auto-queue new targets
- Report now includes `recommended_next_scans[]` with actionable next steps
- New API endpoint `POST /api/scans/{id}/start-recommended`
- Frontend "Next Steps" tab with one-click "Start Scan" buttons per recommendation

## Risk: Tier 2 (new tool, new API endpoint, prompt changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)